### PR TITLE
Fixes wrong image being used in deploy-template example

### DIFF
--- a/deploy-template/compose.yml
+++ b/deploy-template/compose.yml
@@ -16,7 +16,7 @@ services:
       - POSTGRES_USER=drop
       - POSTGRES_DB=drop
   drop:
-    image: registry.deepcore.dev/drop-oss/drop/main:latest
+    image: decduck/drop-oss:v0.2.0-beta
     depends_on:
       postgres:
         condition: service_healthy


### PR DESCRIPTION
This PR is to fix the docker image used in the deploy-template example. I used the same image as the one from the documentation.