### PR TITLE
Preallocate download streams

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -74,7 +74,8 @@ export default defineNuxtConfig({
 
   vite: {
     plugins: [
-      tailwindcss(),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tailwindcss() as any,
       // only used in dev server, not build because nitro sucks
       // see build hook below
       viteStaticCopy({
@@ -84,7 +85,8 @@ export default defineNuxtConfig({
             dest: "twemoji",
           },
         ],
-      }),
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      }) as any,
     ],
   },
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -85,7 +85,7 @@ export default defineNuxtConfig({
             dest: "twemoji",
           },
         ],
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
       }) as any,
     ],
   },

--- a/server/api/v2/client/chunk.post.ts
+++ b/server/api/v2/client/chunk.post.ts
@@ -9,7 +9,10 @@ const GetChunk = type({
   files: type({
     filename: "string",
     chunkIndex: "number",
-  }).array().atLeastLength(1).atMostLength(256),
+  })
+    .array()
+    .atLeastLength(1)
+    .atMostLength(256),
 }).configure(throwingArktype);
 
 export default defineEventHandler(async (h3) => {

--- a/server/api/v2/client/chunk.post.ts
+++ b/server/api/v2/client/chunk.post.ts
@@ -9,7 +9,7 @@ const GetChunk = type({
   files: type({
     filename: "string",
     chunkIndex: "number",
-  }).array(),
+  }).array().atLeastLength(1).atMostLength(256),
 }).configure(throwingArktype);
 
 export default defineEventHandler(async (h3) => {
@@ -46,21 +46,27 @@ export default defineEventHandler(async (h3) => {
     streamFiles.map((e) => e.end - e.start).join(","),
   ); // Non-standard header, but we're cool like that 😎
 
-  for (const file of streamFiles) {
-    const gameReadStream = await libraryManager.readFile(
-      context.libraryId,
-      context.libraryPath,
-      context.versionName,
-      file.filename,
-      { start: file.start, end: file.end },
-    );
-    if (!gameReadStream)
-      throw createError({
-        statusCode: 500,
-        statusMessage: "Failed to create read stream",
-      });
+  const streams = await Promise.all(
+    streamFiles.map(async (file) => {
+      const gameReadStream = await libraryManager.readFile(
+        context.libraryId,
+        context.libraryPath,
+        context.versionName,
+        file.filename,
+        { start: file.start, end: file.end },
+      );
+      if (!gameReadStream)
+        throw createError({
+          statusCode: 500,
+          statusMessage: "Failed to create read stream",
+        });
+      return { ...file, stream: gameReadStream };
+    }),
+  );
+
+  for (const file of streams) {
     let length = 0;
-    await gameReadStream.pipeTo(
+    await file.stream.pipeTo(
       new WritableStream({
         write(chunk) {
           h3.node.res.write(chunk);

--- a/server/middleware/latency.ts
+++ b/server/middleware/latency.ts
@@ -1,3 +1,3 @@
 export default defineEventHandler(async () => {
-  await new Promise((r) => setTimeout(r, 1400));
+  // await new Promise((r) => setTimeout(r, 1400));
 });

--- a/server/middleware/latency.ts
+++ b/server/middleware/latency.ts
@@ -1,3 +1,3 @@
 export default defineEventHandler(async () => {
-  // await new Promise((r) => setTimeout(r, 700));
+  await new Promise((r) => setTimeout(r, 1400));
 });


### PR DESCRIPTION
Significantly boosts high IO-latency downloads, by reducing the time waiting before files to come down the request.

On my NFS spinning-rust NAS, this literally doubled my download speed, even with the 1400ms of debug latency. 