### PR TITLE
Fix sign-in page errors, etc

### DIFF
--- a/components/Auth/Simple.vue
+++ b/components/Auth/Simple.vue
@@ -98,9 +98,14 @@ const rememberMe = ref(false);
 const loading = ref(false);
 
 async function passkeyAutofill() {
-  const silentWebauthnOptions = await $dropFetch("/api/v1/auth/passkey/start", {
-    method: "POST",
-  });
+  let silentWebauthnOptions;
+  try {
+    silentWebauthnOptions = await $dropFetch("/api/v1/auth/passkey/start", {
+      method: "POST",
+    });
+  } catch {
+    return;
+  }
 
   const result = await startAuthentication({
     optionsJSON: silentWebauthnOptions,
@@ -122,8 +127,7 @@ onMounted(async () => {
     try {
       await passkeyAutofill();
     } catch (response) {
-      const message =
-        (response as FetchError).statusMessage || t("errors.unknown");
+      const message = (response as FetchError).message || t("errors.unknown");
       error.value = message;
     } finally {
       loading.value = false;
@@ -141,7 +145,7 @@ function signin_wrapper() {
   loading.value = true;
   signin()
     .catch((response) => {
-      const message = response.statusMessage || t("errors.unknown");
+      const message = response.message || t("errors.unknown");
       error.value = message;
     })
     .finally(() => {

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -8,5 +8,5 @@ useHead({
 });
 
 const router = useRouter();
-router.replace("/store");
+router.push("/store");
 </script>


### PR DESCRIPTION
Fixes some small issues:
- The redirect from / to /store *should* work better
- Passkey autofill now should fail silently if not supported
- The sign in page now shows the error from the server instead of "An unknown error occurred"