### PR TITLE
Add z-index to ComboboxOptions (#271)

### DIFF
--- a/components/Selector/MultiItem.vue
+++ b/components/Selector/MultiItem.vue
@@ -46,7 +46,7 @@
 
         <ComboboxOptions
           v-if="filteredItems.length > 0 || search.length > 0"
-          class="absolute mt-1 max-h-60 w-full overflow-auto rounded-md bg-zinc-900 py-1 text-base shadow-lg ring-1 ring-white/5 focus:outline-hidden sm:text-sm"
+          class="absolute z-50 mt-1 max-h-60 w-full overflow-auto rounded-md bg-zinc-900 py-1 text-base shadow-lg ring-1 ring-white/5 focus:outline-hidden sm:text-sm"
         >
           <ComboboxOption
             v-for="item in filteredItems"


### PR DESCRIPTION
I never used headlessui before, so I have no idea why this is needed, but it looks like this fixes the problem. I think a high z-index is alright, because there shouldn't be things that should lie above the options.