### PR TITLE
[Proposal] Add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,34 +1,11 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the
 // README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
 {
-  "name": "Node.js",
-  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "dockerComposeFile": "docker-compose.yml",
-  "service": "app",
-  "workspaceFolder": "/workspaces/drop",
-  "runServices": [ "db", "app" ],
-  "shutdownAction": "stopCompose",
   "containerEnv": {
     "DATABASE_URL": "postgres://drop:drop@db:5432/drop",
     "EXTERNAL_URL": "http://localhost:4000",
     "NUXT_PORT": "4000"
   },
-
-  // Features to add to the dev container. More info: https://containers.dev/features.
-  "features": {
-    "ghcr.io/devcontainers/features/node:1": { },
-    "ghcr.io/devcontainers/features/rust:1": {
-      "version": "nightly-2026-03-29"
-    },
-    "ghcr.io/devcontainers-extra/features/protoc:1": { }
-  },
-
-  // Use 'forwardPorts' to make a list of ports inside the container available locally.
-  // "forwardPorts": [],
-
-  // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "git submodule update --init --recursive",
-  "postStartCommand": "pnpm install && pnpm prisma migrate deploy && cd torrential && cargo build --release && cd ..",
 
   // Configure tool-specific properties.
   "customizations": {
@@ -44,8 +21,32 @@
         "dbaeumer.vscode-eslint"
       ]
     }
-  }
+  },
 
   // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
   // "remoteUser": "root"
+
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "dockerComposeFile": "docker-compose.yml",
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers-extra/features/protoc:1": {},
+    "ghcr.io/devcontainers/features/node:1": {},
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "nightly-2026-03-29"
+    }
+  },
+
+  "name": "Node.js",
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "git submodule update --init --recursive",
+  "postStartCommand": "pnpm install && pnpm prisma migrate deploy && cd torrential && cargo build --release && cd ..",
+
+  "runServices": ["db", "app"],
+  "service": "app",
+  "shutdownAction": "stopCompose",
+  "workspaceFolder": "/workspaces/drop"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,51 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/javascript-node
+{
+  "name": "Node.js",
+  // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "app",
+  "workspaceFolder": "/workspaces/drop",
+  "runServices": [ "db", "app" ],
+  "shutdownAction": "stopCompose",
+  "containerEnv": {
+    "DATABASE_URL": "postgres://drop:drop@db:5432/drop",
+    "EXTERNAL_URL": "http://localhost:4000",
+    "NUXT_PORT": "4000"
+  },
+
+  // Features to add to the dev container. More info: https://containers.dev/features.
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": { },
+    "ghcr.io/devcontainers/features/rust:1": {
+      "version": "nightly-2026-03-29"
+    },
+    "ghcr.io/devcontainers-extra/features/protoc:1": { }
+  },
+
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "git submodule update --init --recursive",
+  "postStartCommand": "pnpm install && pnpm prisma migrate deploy && cd torrential && cargo build --release && cd ..",
+
+  // Configure tool-specific properties.
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "lokalise.i18n-ally",
+        "esbenp.prettier-vscode",
+        "Prisma.prisma",
+        "bradlc.vscode-tailwindcss",
+        "Vue.volar",
+        "arktypeio.arkdark",
+        "EditorConfig.EditorConfig",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  }
+
+  // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+  // "remoteUser": "root"
+}

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  app:
+    image: mcr.microsoft.com/devcontainers/base:noble
+    command: sleep infinity
+    volumes:
+      - ..:/workspaces/drop:cached
+    depends_on:
+      db:
+        condition: service_healthy
+
+  db:
+    image: postgres:14-alpine
+    environment:
+      POSTGRES_USER: drop
+      POSTGRES_PASSWORD: drop
+      POSTGRES_DB: drop
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U drop -d drop"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+volumes:
+  pgdata:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ dist
 # Node dependencies
 node_modules
 .yarn
+.pnpm-store
 
 # Logs
 logs


### PR DESCRIPTION
While working on https://github.com/Drop-OSS/drop/pull/375 I had to do some things to setup a working environment. To simplify the working inside of this project I want to propose to provide a [devcontainer](https://containers.dev/) which containerizes the workspace and makes it easy to make it reproducible. I think this makes it much easier for new people to jump into a project.

I decided to include a postgres instance which automatically runs with the devcontainer - I have no experience with prisma but it looks like you could also use that to spin up instances and switch between them easily by changing the port inside the .env file. But I hope this setup is okay as well.

If this is not okay, please tell me if I can do something to make this work. But if you decide that you don't want to include this, this is of course okay as well. Thanks for your work! :pray: 