### PR TITLE
Auto-fill launch name on version import (#373)

### DIFF
--- a/server/components/ImportVersionLaunchRow.vue
+++ b/server/components/ImportVersionLaunchRow.vue
@@ -292,6 +292,18 @@ const launchFilteredVersionGuesses = computed(() =>
 
 function updateLaunchCommand(command: string) {
   launchConfiguration.value.launch = command;
+
+  // Auto-fill name from filename if user hasn't set one (#373)
+  if (!launchConfiguration.value.name) {
+    const guess = props.versionGuesses?.find((v) => v.filename === command);
+    if (guess?.type === "emulator") {
+      launchConfiguration.value.name = guess.launchName;
+    } else {
+      const basename = command.split("/").pop() ?? command;
+      launchConfiguration.value.name = basename.replace(/\.[^.]+$/, "");
+    }
+  }
+
   if (launchConfiguration.value.platform === undefined) {
     const autosetGuess = props.versionGuesses?.find(
       (v) => v.filename == command,


### PR DESCRIPTION
First MR to the project! Took on an easy issue.

Fixes #373

When selecting an executable from the dropdown during version import, the name field is now auto-filled from the filename. For emulator launches, uses the pre-configured launch name. For platform launches, this strips the path and extension (e.g. SkyrimSE.exe now auto-names as SkyrimSE). Only auto-fills when the name field is empty, so user-typed custom names are saved.