### PR TITLE
Adding groups logic and restrictions

### DIFF
--- a/server/i18n/locales/de.json
+++ b/server/i18n/locales/de.json
@@ -699,6 +699,26 @@
       "description": "Verwalte Benutzer auf deiner Drop-Instanz und konfiguriere deine Authentifizierungsmethode.",
       "displayNameHeader": "Anzeigename",
       "emailHeader": "E-Mail",
+      "groups": {
+        "addBannedRating": "Gesperrte Einstufung hinzufügen",
+        "addMember": "Benutzer auswählen...",
+        "bannedRatings": "Gesperrte Alterseinstufungen",
+        "createGroup": "Gruppe erstellen",
+        "deleteConfirm": "Sind Sie sicher, dass Sie diese Gruppe löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+        "deleteGroup": "Löschen",
+        "description": "Benutzergruppen und Altersbeschränkungen verwalten.",
+        "descriptionField": "Beschreibung",
+        "details": "Details",
+        "members": "Mitglieder",
+        "name": "Name",
+        "noBannedRatings": "Keine gesperrten Einstufungen konfiguriert.",
+        "noMembers": "Keine Mitglieder in dieser Gruppe.",
+        "oidcManagedNote": "Die Gruppenmitgliedschaft wird von Ihrem OIDC-Anbieter verwaltet. Mitglieder werden bei der Anmeldung automatisch synchronisiert. Um die Gruppenmitgliedschaft zu ändern, aktualisieren Sie die Gruppenzuweisungen Ihres Identitätsanbieters.",
+        "removeBannedRating": "Entfernen",
+        "removeMember": "Entfernen",
+        "title": "Benutzergruppen",
+        "unratedNote": "Spiele ohne Alterseinstufung werden für Benutzer in dieser Gruppe ebenfalls ausgeblendet."
+      },
       "normalUserLabel": "Normaler Benutzer",
       "simple": {
         "adminInvitation": "Admin Einladung",
@@ -732,27 +752,7 @@
         "userInvitation": "Benutzereinladung"
       },
       "srEditLabel": "Bearbeiten",
-      "usernameHeader": "Nutzername",
-      "groups": {
-        "title": "Benutzergruppen",
-        "description": "Benutzergruppen und Altersbeschränkungen verwalten.",
-        "createGroup": "Gruppe erstellen",
-        "name": "Name",
-        "descriptionField": "Beschreibung",
-        "details": "Details",
-        "members": "Mitglieder",
-        "addMember": "Benutzer auswählen...",
-        "removeMember": "Entfernen",
-        "noMembers": "Keine Mitglieder in dieser Gruppe.",
-        "oidcManagedNote": "Die Gruppenmitgliedschaft wird von Ihrem OIDC-Anbieter verwaltet. Mitglieder werden bei der Anmeldung automatisch synchronisiert. Um die Gruppenmitgliedschaft zu ändern, aktualisieren Sie die Gruppenzuweisungen Ihres Identitätsanbieters.",
-        "bannedRatings": "Gesperrte Alterseinstufungen",
-        "addBannedRating": "Gesperrte Einstufung hinzufügen",
-        "removeBannedRating": "Entfernen",
-        "noBannedRatings": "Keine gesperrten Einstufungen konfiguriert.",
-        "unratedNote": "Spiele ohne Alterseinstufung werden für Benutzer in dieser Gruppe ebenfalls ausgeblendet.",
-        "deleteConfirm": "Sind Sie sicher, dass Sie diese Gruppe löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
-        "deleteGroup": "Löschen"
-      }
+      "usernameHeader": "Nutzername"
     }
   },
   "welcome": "Deutsche, willkommen!"

--- a/server/i18n/locales/de.json
+++ b/server/i18n/locales/de.json
@@ -732,7 +732,27 @@
         "userInvitation": "Benutzereinladung"
       },
       "srEditLabel": "Bearbeiten",
-      "usernameHeader": "Nutzername"
+      "usernameHeader": "Nutzername",
+      "groups": {
+        "title": "Benutzergruppen",
+        "description": "Benutzergruppen und Altersbeschränkungen verwalten.",
+        "createGroup": "Gruppe erstellen",
+        "name": "Name",
+        "descriptionField": "Beschreibung",
+        "details": "Details",
+        "members": "Mitglieder",
+        "addMember": "Benutzer auswählen...",
+        "removeMember": "Entfernen",
+        "noMembers": "Keine Mitglieder in dieser Gruppe.",
+        "oidcManagedNote": "Die Gruppenmitgliedschaft wird von Ihrem OIDC-Anbieter verwaltet. Mitglieder werden bei der Anmeldung automatisch synchronisiert. Um die Gruppenmitgliedschaft zu ändern, aktualisieren Sie die Gruppenzuweisungen Ihres Identitätsanbieters.",
+        "bannedRatings": "Gesperrte Alterseinstufungen",
+        "addBannedRating": "Gesperrte Einstufung hinzufügen",
+        "removeBannedRating": "Entfernen",
+        "noBannedRatings": "Keine gesperrten Einstufungen konfiguriert.",
+        "unratedNote": "Spiele ohne Alterseinstufung werden für Benutzer in dieser Gruppe ebenfalls ausgeblendet.",
+        "deleteConfirm": "Sind Sie sicher, dass Sie diese Gruppe löschen möchten? Diese Aktion kann nicht rückgängig gemacht werden.",
+        "deleteGroup": "Löschen"
+      }
     }
   },
   "welcome": "Deutsche, willkommen!"

--- a/server/i18n/locales/en_pirate.json
+++ b/server/i18n/locales/en_pirate.json
@@ -531,7 +531,27 @@
         "userInvitation": "Crewman's Invitation"
       },
       "srEditLabel": "Amend",
-      "usernameHeader": "Crew Name"
+      "usernameHeader": "Crew Name",
+      "groups": {
+        "title": "Crew Groups",
+        "description": "Manage yer crew groups and age restrictions on the plunder.",
+        "createGroup": "Form a Crew",
+        "name": "Name",
+        "descriptionField": "Description",
+        "details": "Details",
+        "members": "Crew Members",
+        "addMember": "Pick a scallywag...",
+        "removeMember": "Cast overboard",
+        "noMembers": "No souls in this crew.",
+        "oidcManagedNote": "Crew membership be managed by yer OIDC harbourmaster. Members be synced when they come aboard. To change crew membership, update yer identity provider's assignments.",
+        "bannedRatings": "Forbidden Ratings",
+        "addBannedRating": "Add forbidden rating",
+        "removeBannedRating": "Remove",
+        "noBannedRatings": "No forbidden ratings set, captain.",
+        "unratedNote": "Unrated plunder will also be hidden from scallywags in this crew.",
+        "deleteConfirm": "Be ye sure ye want to disband this crew? There be no turnin' back!",
+        "deleteGroup": "Disband"
+      }
     }
   },
   "welcome": "Ahoy, Welcome!"

--- a/server/i18n/locales/en_pirate.json
+++ b/server/i18n/locales/en_pirate.json
@@ -498,6 +498,26 @@
       "description": "Manage the crew on yer Drop vessel, and set yer passage methods, savvy?",
       "displayNameHeader": "Scallywag Name",
       "emailHeader": "Salty Mail",
+      "groups": {
+        "addBannedRating": "Add forbidden rating",
+        "addMember": "Pick a scallywag...",
+        "bannedRatings": "Forbidden Ratings",
+        "createGroup": "Form a Crew",
+        "deleteConfirm": "Be ye sure ye want to disband this crew? There be no turnin' back!",
+        "deleteGroup": "Disband",
+        "description": "Manage yer crew groups and age restrictions on the plunder.",
+        "descriptionField": "Description",
+        "details": "Details",
+        "members": "Crew Members",
+        "name": "Name",
+        "noBannedRatings": "No forbidden ratings set, captain.",
+        "noMembers": "No souls in this crew.",
+        "oidcManagedNote": "Crew membership be managed by yer OIDC harbourmaster. Members be synced when they come aboard. To change crew membership, update yer identity provider's assignments.",
+        "removeBannedRating": "Remove",
+        "removeMember": "Cast overboard",
+        "title": "Crew Groups",
+        "unratedNote": "Unrated plunder will also be hidden from scallywags in this crew."
+      },
       "normalUserLabel": "Common crewman",
       "simple": {
         "adminInvitation": "Cap'n's Invitation",
@@ -531,27 +551,7 @@
         "userInvitation": "Crewman's Invitation"
       },
       "srEditLabel": "Amend",
-      "usernameHeader": "Crew Name",
-      "groups": {
-        "title": "Crew Groups",
-        "description": "Manage yer crew groups and age restrictions on the plunder.",
-        "createGroup": "Form a Crew",
-        "name": "Name",
-        "descriptionField": "Description",
-        "details": "Details",
-        "members": "Crew Members",
-        "addMember": "Pick a scallywag...",
-        "removeMember": "Cast overboard",
-        "noMembers": "No souls in this crew.",
-        "oidcManagedNote": "Crew membership be managed by yer OIDC harbourmaster. Members be synced when they come aboard. To change crew membership, update yer identity provider's assignments.",
-        "bannedRatings": "Forbidden Ratings",
-        "addBannedRating": "Add forbidden rating",
-        "removeBannedRating": "Remove",
-        "noBannedRatings": "No forbidden ratings set, captain.",
-        "unratedNote": "Unrated plunder will also be hidden from scallywags in this crew.",
-        "deleteConfirm": "Be ye sure ye want to disband this crew? There be no turnin' back!",
-        "deleteGroup": "Disband"
-      }
+      "usernameHeader": "Crew Name"
     }
   },
   "welcome": "Ahoy, Welcome!"

--- a/server/i18n/locales/en_us.json
+++ b/server/i18n/locales/en_us.json
@@ -850,7 +850,28 @@
         "userInvitation": "User invitation"
       },
       "srEditLabel": "Edit",
-      "usernameHeader": "Username"
+      "usernameHeader": "Username",
+      "groups": {
+        "title": "User Groups",
+        "description": "Manage user groups and age rating restrictions.",
+        "createGroup": "Create Group",
+        "name": "Name",
+        "descriptionField": "Description",
+        "details": "Details",
+        "members": "Members",
+        "addMember": "Select a user...",
+        "removeMember": "Remove",
+        "noMembers": "No members in this group.",
+        "oidcManagedNote": "Group membership is managed by your OIDC provider. Members are automatically synced when users log in. To change group membership, update your identity provider's group assignments.",
+        "bannedRatings": "Banned Ratings",
+        "addBannedRating": "Add banned rating",
+        "removeBannedRating": "Remove",
+        "noBannedRatings": "No banned ratings configured.",
+        "unratedNote": "Games without age ratings will also be hidden from users in this group.",
+        "deleteConfirm": "Are you sure you want to delete this group? This action cannot be undone.",
+        "deleteGroup": "Delete",
+        "groupsLink": "Groups {arrow}"
+      }
     }
   },
   "welcome": "American, Welcome!"

--- a/server/i18n/locales/en_us.json
+++ b/server/i18n/locales/en_us.json
@@ -869,8 +869,7 @@
         "noBannedRatings": "No banned ratings configured.",
         "unratedNote": "Games without age ratings will also be hidden from users in this group.",
         "deleteConfirm": "Are you sure you want to delete this group? This action cannot be undone.",
-        "deleteGroup": "Delete",
-        "groupsLink": "Groups {arrow}"
+        "deleteGroup": "Delete"
       }
     }
   },

--- a/server/i18n/locales/en_us.json
+++ b/server/i18n/locales/en_us.json
@@ -817,6 +817,26 @@
       "description": "Manage the users on your Drop instance, and configure your authentication methods.",
       "displayNameHeader": "Display Name",
       "emailHeader": "Email",
+      "groups": {
+        "addBannedRating": "Add banned rating",
+        "addMember": "Select a user...",
+        "bannedRatings": "Banned Ratings",
+        "createGroup": "Create Group",
+        "deleteConfirm": "Are you sure you want to delete this group? This action cannot be undone.",
+        "deleteGroup": "Delete",
+        "description": "Manage user groups and age rating restrictions.",
+        "descriptionField": "Description",
+        "details": "Details",
+        "members": "Members",
+        "name": "Name",
+        "noBannedRatings": "No banned ratings configured.",
+        "noMembers": "No members in this group.",
+        "oidcManagedNote": "Group membership is managed by your OIDC provider. Members are automatically synced when users log in. To change group membership, update your identity provider's group assignments.",
+        "removeBannedRating": "Remove",
+        "removeMember": "Remove",
+        "title": "User Groups",
+        "unratedNote": "Games without age ratings will also be hidden from users in this group."
+      },
       "normalUserLabel": "Normal user",
       "simple": {
         "adminInvitation": "Admin invitation",
@@ -850,27 +870,7 @@
         "userInvitation": "User invitation"
       },
       "srEditLabel": "Edit",
-      "usernameHeader": "Username",
-      "groups": {
-        "title": "User Groups",
-        "description": "Manage user groups and age rating restrictions.",
-        "createGroup": "Create Group",
-        "name": "Name",
-        "descriptionField": "Description",
-        "details": "Details",
-        "members": "Members",
-        "addMember": "Select a user...",
-        "removeMember": "Remove",
-        "noMembers": "No members in this group.",
-        "oidcManagedNote": "Group membership is managed by your OIDC provider. Members are automatically synced when users log in. To change group membership, update your identity provider's group assignments.",
-        "bannedRatings": "Banned Ratings",
-        "addBannedRating": "Add banned rating",
-        "removeBannedRating": "Remove",
-        "noBannedRatings": "No banned ratings configured.",
-        "unratedNote": "Games without age ratings will also be hidden from users in this group.",
-        "deleteConfirm": "Are you sure you want to delete this group? This action cannot be undone.",
-        "deleteGroup": "Delete"
-      }
+      "usernameHeader": "Username"
     }
   },
   "welcome": "American, Welcome!"

--- a/server/i18n/locales/fr.json
+++ b/server/i18n/locales/fr.json
@@ -699,6 +699,26 @@
       "description": "Gérer les utilisateurs sur votre instance Drop, et configurer vos méthodes d'authentification.",
       "displayNameHeader": "Nom d'affichage",
       "emailHeader": "Email",
+      "groups": {
+        "addBannedRating": "Ajouter une classification interdite",
+        "addMember": "Sélectionner un utilisateur...",
+        "bannedRatings": "Classifications interdites",
+        "createGroup": "Créer un groupe",
+        "deleteConfirm": "Êtes-vous sûr de vouloir supprimer ce groupe ? Cette action est irréversible.",
+        "deleteGroup": "Supprimer",
+        "description": "Gérer les groupes d'utilisateurs et les restrictions d'âge.",
+        "descriptionField": "Description",
+        "details": "Détails",
+        "members": "Membres",
+        "name": "Nom",
+        "noBannedRatings": "Aucune classification interdite configurée.",
+        "noMembers": "Aucun membre dans ce groupe.",
+        "oidcManagedNote": "L'appartenance aux groupes est gérée par votre fournisseur OIDC. Les membres sont automatiquement synchronisés lors de la connexion. Pour modifier l'appartenance aux groupes, mettez à jour les affectations de groupes de votre fournisseur d'identité.",
+        "removeBannedRating": "Retirer",
+        "removeMember": "Retirer",
+        "title": "Groupes d'utilisateurs",
+        "unratedNote": "Les jeux sans classification d'âge seront également masqués pour les utilisateurs de ce groupe."
+      },
       "normalUserLabel": "Utilisateur normal",
       "simple": {
         "adminInvitation": "Invitation adminstrateur",
@@ -732,27 +752,7 @@
         "userInvitation": "Invitation utilisateur"
       },
       "srEditLabel": "Éditer",
-      "usernameHeader": "Nom d'utilisateur",
-      "groups": {
-        "title": "Groupes d'utilisateurs",
-        "description": "Gérer les groupes d'utilisateurs et les restrictions d'âge.",
-        "createGroup": "Créer un groupe",
-        "name": "Nom",
-        "descriptionField": "Description",
-        "details": "Détails",
-        "members": "Membres",
-        "addMember": "Sélectionner un utilisateur...",
-        "removeMember": "Retirer",
-        "noMembers": "Aucun membre dans ce groupe.",
-        "oidcManagedNote": "L'appartenance aux groupes est gérée par votre fournisseur OIDC. Les membres sont automatiquement synchronisés lors de la connexion. Pour modifier l'appartenance aux groupes, mettez à jour les affectations de groupes de votre fournisseur d'identité.",
-        "bannedRatings": "Classifications interdites",
-        "addBannedRating": "Ajouter une classification interdite",
-        "removeBannedRating": "Retirer",
-        "noBannedRatings": "Aucune classification interdite configurée.",
-        "unratedNote": "Les jeux sans classification d'âge seront également masqués pour les utilisateurs de ce groupe.",
-        "deleteConfirm": "Êtes-vous sûr de vouloir supprimer ce groupe ? Cette action est irréversible.",
-        "deleteGroup": "Supprimer"
-      }
+      "usernameHeader": "Nom d'utilisateur"
     }
   },
   "welcome": "Américain, bienvenue !"

--- a/server/i18n/locales/fr.json
+++ b/server/i18n/locales/fr.json
@@ -732,7 +732,27 @@
         "userInvitation": "Invitation utilisateur"
       },
       "srEditLabel": "Éditer",
-      "usernameHeader": "Nom d'utilisateur"
+      "usernameHeader": "Nom d'utilisateur",
+      "groups": {
+        "title": "Groupes d'utilisateurs",
+        "description": "Gérer les groupes d'utilisateurs et les restrictions d'âge.",
+        "createGroup": "Créer un groupe",
+        "name": "Nom",
+        "descriptionField": "Description",
+        "details": "Détails",
+        "members": "Membres",
+        "addMember": "Sélectionner un utilisateur...",
+        "removeMember": "Retirer",
+        "noMembers": "Aucun membre dans ce groupe.",
+        "oidcManagedNote": "L'appartenance aux groupes est gérée par votre fournisseur OIDC. Les membres sont automatiquement synchronisés lors de la connexion. Pour modifier l'appartenance aux groupes, mettez à jour les affectations de groupes de votre fournisseur d'identité.",
+        "bannedRatings": "Classifications interdites",
+        "addBannedRating": "Ajouter une classification interdite",
+        "removeBannedRating": "Retirer",
+        "noBannedRatings": "Aucune classification interdite configurée.",
+        "unratedNote": "Les jeux sans classification d'âge seront également masqués pour les utilisateurs de ce groupe.",
+        "deleteConfirm": "Êtes-vous sûr de vouloir supprimer ce groupe ? Cette action est irréversible.",
+        "deleteGroup": "Supprimer"
+      }
     }
   },
   "welcome": "Américain, bienvenue !"

--- a/server/i18n/locales/pl.json
+++ b/server/i18n/locales/pl.json
@@ -675,6 +675,26 @@
       "description": "Zarządzaj użytkownikami na twojej instancji Drop, i skonfiguruj swoje metody uwierzytelniania.",
       "displayNameHeader": "Nazwa Wyświetlana",
       "emailHeader": "Email",
+      "groups": {
+        "addBannedRating": "Dodaj zablokowaną kategorię",
+        "addMember": "Wybierz użytkownika...",
+        "bannedRatings": "Zablokowane kategorie wiekowe",
+        "createGroup": "Utwórz grupę",
+        "deleteConfirm": "Czy na pewno chcesz usunąć tę grupę? Tej akcji nie można cofnąć.",
+        "deleteGroup": "Usuń",
+        "description": "Zarządzaj grupami użytkowników i ograniczeniami wiekowymi.",
+        "descriptionField": "Opis",
+        "details": "Szczegóły",
+        "members": "Członkowie",
+        "name": "Nazwa",
+        "noBannedRatings": "Brak skonfigurowanych zablokowanych kategorii.",
+        "noMembers": "Brak członków w tej grupie.",
+        "oidcManagedNote": "Członkostwo w grupach jest zarządzane przez dostawcę OIDC. Członkowie są automatycznie synchronizowani podczas logowania. Aby zmienić członkostwo w grupach, zaktualizuj przypisania grup u dostawcy tożsamości.",
+        "removeBannedRating": "Usuń",
+        "removeMember": "Usuń",
+        "title": "Grupy użytkowników",
+        "unratedNote": "Gry bez kategorii wiekowej będą również ukryte przed użytkownikami w tej grupie."
+      },
       "normalUserLabel": "Normalny użytkownik",
       "simple": {
         "adminInvitation": "Zaproszenie administratora",
@@ -708,27 +728,7 @@
         "userInvitation": "Zaproszenie użytkownika"
       },
       "srEditLabel": "Edytuj",
-      "usernameHeader": "Nazwa Użytkownika",
-      "groups": {
-        "title": "Grupy użytkowników",
-        "description": "Zarządzaj grupami użytkowników i ograniczeniami wiekowymi.",
-        "createGroup": "Utwórz grupę",
-        "name": "Nazwa",
-        "descriptionField": "Opis",
-        "details": "Szczegóły",
-        "members": "Członkowie",
-        "addMember": "Wybierz użytkownika...",
-        "removeMember": "Usuń",
-        "noMembers": "Brak członków w tej grupie.",
-        "oidcManagedNote": "Członkostwo w grupach jest zarządzane przez dostawcę OIDC. Członkowie są automatycznie synchronizowani podczas logowania. Aby zmienić członkostwo w grupach, zaktualizuj przypisania grup u dostawcy tożsamości.",
-        "bannedRatings": "Zablokowane kategorie wiekowe",
-        "addBannedRating": "Dodaj zablokowaną kategorię",
-        "removeBannedRating": "Usuń",
-        "noBannedRatings": "Brak skonfigurowanych zablokowanych kategorii.",
-        "unratedNote": "Gry bez kategorii wiekowej będą również ukryte przed użytkownikami w tej grupie.",
-        "deleteConfirm": "Czy na pewno chcesz usunąć tę grupę? Tej akcji nie można cofnąć.",
-        "deleteGroup": "Usuń"
-      }
+      "usernameHeader": "Nazwa Użytkownika"
     }
   },
   "welcome": "Polaku, Witaj!"

--- a/server/i18n/locales/pl.json
+++ b/server/i18n/locales/pl.json
@@ -708,7 +708,27 @@
         "userInvitation": "Zaproszenie użytkownika"
       },
       "srEditLabel": "Edytuj",
-      "usernameHeader": "Nazwa Użytkownika"
+      "usernameHeader": "Nazwa Użytkownika",
+      "groups": {
+        "title": "Grupy użytkowników",
+        "description": "Zarządzaj grupami użytkowników i ograniczeniami wiekowymi.",
+        "createGroup": "Utwórz grupę",
+        "name": "Nazwa",
+        "descriptionField": "Opis",
+        "details": "Szczegóły",
+        "members": "Członkowie",
+        "addMember": "Wybierz użytkownika...",
+        "removeMember": "Usuń",
+        "noMembers": "Brak członków w tej grupie.",
+        "oidcManagedNote": "Członkostwo w grupach jest zarządzane przez dostawcę OIDC. Członkowie są automatycznie synchronizowani podczas logowania. Aby zmienić członkostwo w grupach, zaktualizuj przypisania grup u dostawcy tożsamości.",
+        "bannedRatings": "Zablokowane kategorie wiekowe",
+        "addBannedRating": "Dodaj zablokowaną kategorię",
+        "removeBannedRating": "Usuń",
+        "noBannedRatings": "Brak skonfigurowanych zablokowanych kategorii.",
+        "unratedNote": "Gry bez kategorii wiekowej będą również ukryte przed użytkownikami w tej grupie.",
+        "deleteConfirm": "Czy na pewno chcesz usunąć tę grupę? Tej akcji nie można cofnąć.",
+        "deleteGroup": "Usuń"
+      }
     }
   },
   "welcome": "Polaku, Witaj!"

--- a/server/pages/admin/users/groups/[id].vue
+++ b/server/pages/admin/users/groups/[id].vue
@@ -271,8 +271,9 @@ const fetchAllUsers = async () => {
 // Check OIDC
 const checkOidc = async () => {
   try {
-    const auth = await $dropFetch<Record<string, unknown>>("/api/v1/admin/auth");
-    oidcEnabled.value = !!auth[("OpenID" as AuthMec)];
+    const auth =
+      await $dropFetch<Record<string, unknown>>("/api/v1/admin/auth");
+    oidcEnabled.value = !!auth["OpenID" as AuthMec];
   } catch {
     oidcEnabled.value = false;
   }

--- a/server/pages/admin/users/groups/[id].vue
+++ b/server/pages/admin/users/groups/[id].vue
@@ -1,0 +1,356 @@
+<template>
+  <div v-if="group">
+    <h1 class="text-xl font-semibold text-zinc-100">
+      {{ group.name }}
+    </h1>
+    <p class="mt-1 text-sm text-zinc-400">
+      {{ group.description }}
+    </p>
+
+    <!-- Details Section -->
+    <div class="mt-8 rounded-lg border border-zinc-800 bg-zinc-900 p-6">
+      <h2 class="text-base font-semibold text-zinc-100 mb-4">
+        {{ $t("users.admin.groups.details") }}
+      </h2>
+      <div class="space-y-4 max-w-md">
+        <div>
+          <label class="text-sm/6 font-medium text-zinc-100">
+            {{ $t("users.admin.groups.name") }}
+          </label>
+          <input
+            v-model="editName"
+            type="text"
+            class="mt-1 block w-full rounded-md bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline outline-1 -outline-offset-1 outline-zinc-700 focus:outline-blue-600"
+          />
+        </div>
+        <div>
+          <label class="text-sm/6 font-medium text-zinc-100">
+            {{ $t("users.admin.groups.descriptionField") }}
+          </label>
+          <input
+            v-model="editDescription"
+            type="text"
+            class="mt-1 block w-full rounded-md bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline outline-1 -outline-offset-1 outline-zinc-700 focus:outline-blue-600"
+          />
+        </div>
+        <button
+          class="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+          @click="saveDetails"
+        >
+          {{ $t("common.save") }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Members Section -->
+    <div class="mt-8 rounded-lg border border-zinc-800 bg-zinc-900 p-6">
+      <h2 class="text-base font-semibold text-zinc-100 mb-4">
+        {{ $t("users.admin.groups.members") }}
+      </h2>
+
+      <!-- OIDC managed banner -->
+      <div
+        v-if="oidcEnabled"
+        class="mb-4 rounded-md bg-blue-900/30 border border-blue-700/50 p-4"
+      >
+        <p class="text-sm text-blue-300">
+          {{ $t("users.admin.groups.oidcManagedNote") }}
+        </p>
+      </div>
+
+      <div v-if="group.users.length === 0" class="text-sm text-zinc-400">
+        {{ $t("users.admin.groups.noMembers") }}
+      </div>
+      <ul class="space-y-2">
+        <li
+          v-for="member in group.users"
+          :key="member.id"
+          class="flex items-center justify-between rounded-md bg-zinc-800/50 px-3 py-2"
+        >
+          <span class="text-sm text-zinc-100">
+            {{ member.displayName }}
+            <span class="text-zinc-400">({{ member.username }})</span>
+          </span>
+          <button
+            v-if="!oidcEnabled"
+            class="text-sm text-red-400 hover:text-red-300"
+            @click="removeMember(member.id)"
+          >
+            {{ $t("users.admin.groups.removeMember") }}
+          </button>
+        </li>
+      </ul>
+
+      <!-- Add member -->
+      <div v-if="!oidcEnabled" class="mt-4 flex items-center gap-2">
+        <select
+          v-model="selectedUserId"
+          class="rounded-md bg-zinc-800 px-2 py-1.5 text-sm text-zinc-100 outline outline-1 -outline-offset-1 outline-zinc-700 focus:outline-blue-600"
+        >
+          <option value="" disabled>
+            {{ $t("users.admin.groups.addMember") }}
+          </option>
+          <option
+            v-for="user in availableUsers"
+            :key="user.id"
+            :value="user.id"
+          >
+            {{ user.displayName }} ({{ user.username }})
+          </option>
+        </select>
+        <button
+          class="rounded-md bg-blue-600 px-2 py-1 text-sm font-semibold text-white hover:bg-blue-500"
+          :disabled="!selectedUserId"
+          @click="addMember"
+        >
+          {{ $t("add") }}
+        </button>
+      </div>
+    </div>
+
+    <!-- Banned Ratings Section -->
+    <div class="mt-8 rounded-lg border border-zinc-800 bg-zinc-900 p-6">
+      <h2 class="text-base font-semibold text-zinc-100 mb-4">
+        {{ $t("users.admin.groups.bannedRatings") }}
+      </h2>
+      <p class="text-sm text-zinc-400 mb-4">
+        {{ $t("users.admin.groups.unratedNote") }}
+      </p>
+
+      <div
+        v-if="group.bannedAgeRatings.length === 0 && !showAddRating"
+        class="text-sm text-zinc-400"
+      >
+        {{ $t("users.admin.groups.noBannedRatings") }}
+      </div>
+
+      <div class="space-y-2">
+        <div
+          v-for="(br, idx) in group.bannedAgeRatings"
+          :key="br.id"
+          class="flex items-center gap-2"
+        >
+          <span
+            class="inline-flex items-center rounded-full bg-zinc-800 px-2.5 py-0.5 text-sm font-medium text-zinc-100"
+          >
+            {{ br.organization }}: {{ br.rating }}
+          </span>
+          <button
+            type="button"
+            class="text-red-400 hover:text-red-300 text-sm"
+            @click="removeRating(idx)"
+          >
+            {{ $t("users.admin.groups.removeBannedRating") }}
+          </button>
+        </div>
+      </div>
+
+      <div v-if="showAddRating" class="mt-4 flex items-center gap-2">
+        <select
+          v-model="newRatingOrg"
+          class="rounded-md bg-zinc-800 px-2 py-1 text-sm text-zinc-100 outline outline-1 -outline-offset-1 outline-zinc-700 focus:outline-blue-600"
+        >
+          <option v-for="org in organizations" :key="org" :value="org">
+            {{ org }}
+          </option>
+        </select>
+        <select
+          v-model="newRatingValue"
+          :disabled="!newRatingOrg"
+          class="rounded-md bg-zinc-800 px-2 py-1 text-sm text-zinc-100 outline outline-1 -outline-offset-1 outline-zinc-700 focus:outline-blue-600"
+        >
+          <option v-for="r in availableRatingsForOrg" :key="r" :value="r">
+            {{ r }}
+          </option>
+        </select>
+        <button
+          type="button"
+          class="rounded-md bg-blue-600 px-2 py-1 text-sm font-semibold text-white hover:bg-blue-500"
+          :disabled="!newRatingOrg || !newRatingValue"
+          @click="addRating"
+        >
+          {{ $t("add") }}
+        </button>
+        <button
+          type="button"
+          class="text-zinc-400 hover:text-zinc-300 text-sm"
+          @click="showAddRating = false"
+        >
+          {{ $t("cancel") }}
+        </button>
+      </div>
+      <button
+        v-if="!showAddRating"
+        type="button"
+        class="mt-4 text-sm text-blue-400 hover:text-blue-300"
+        @click="showAddRating = true"
+      >
+        {{ $t("users.admin.groups.addBannedRating") }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import type { AuthMec } from "~/prisma/client/enums";
+import {
+  RATINGS_FOR_ORGANIZATION,
+  getAvailableRatings,
+} from "~/utils/ageRatings";
+import { AgeRatingOrganization } from "~/prisma/client/enums";
+
+useHead({ title: "Edit Group" });
+definePageMeta({ layout: "admin" });
+
+const route = useRoute();
+const groupId = route.params.id as string;
+
+interface GroupMember {
+  id: string;
+  username: string;
+  displayName: string;
+}
+
+interface BannedRating {
+  id: string;
+  organization: string;
+  rating: string;
+}
+
+interface GroupDetail {
+  id: string;
+  name: string;
+  description: string;
+  users: GroupMember[];
+  bannedAgeRatings: BannedRating[];
+}
+
+const group = ref<GroupDetail | null>(null);
+const editName = ref("");
+const editDescription = ref("");
+const selectedUserId = ref("");
+const oidcEnabled = ref(false);
+
+// Rating add state
+const showAddRating = ref(false);
+const newRatingOrg = ref<AgeRatingOrganization | "">("");
+const newRatingValue = ref("");
+
+const organizations = Object.values(AgeRatingOrganization);
+
+const availableRatingsForOrg = computed(() => {
+  if (!newRatingOrg.value) return [];
+  return getAvailableRatings(newRatingOrg.value as AgeRatingOrganization);
+});
+
+watch(newRatingOrg, () => {
+  newRatingValue.value = "";
+});
+
+// Fetch group
+const fetchGroup = async () => {
+  group.value = await $dropFetch<GroupDetail>(
+    `/api/v1/admin/groups/${groupId}`,
+  );
+  editName.value = group.value.name;
+  editDescription.value = group.value.description;
+};
+
+// Fetch all users for member add dropdown
+interface UserListItem {
+  id: string;
+  username: string;
+  displayName: string;
+}
+const allUsers = ref<UserListItem[]>([]);
+const fetchAllUsers = async () => {
+  allUsers.value = await $dropFetch<UserListItem[]>("/api/v1/admin/users");
+};
+
+// Check OIDC
+const checkOidc = async () => {
+  try {
+    const auth = await $dropFetch<Record<string, unknown>>("/api/v1/admin/auth");
+    oidcEnabled.value = !!auth[("OpenID" as AuthMec)];
+  } catch {
+    oidcEnabled.value = false;
+  }
+};
+
+await Promise.all([fetchGroup(), fetchAllUsers(), checkOidc()]);
+
+const availableUsers = computed(() => {
+  if (!group.value) return [];
+  const memberIds = new Set(group.value.users.map((u) => u.id));
+  return allUsers.value.filter(
+    (u) => !memberIds.has(u.id) && u.id !== "system",
+  );
+});
+
+const saveDetails = async () => {
+  await $dropFetch(`/api/v1/admin/groups/${groupId}`, {
+    method: "PATCH",
+    body: { name: editName.value, description: editDescription.value },
+  });
+  await fetchGroup();
+};
+
+const addMember = async () => {
+  if (!group.value || !selectedUserId.value) return;
+  const newUserIds = [
+    ...group.value.users.map((u) => u.id),
+    selectedUserId.value,
+  ];
+  await $dropFetch(`/api/v1/admin/groups/${groupId}/members`, {
+    method: "PATCH",
+    body: { userIds: newUserIds },
+  });
+  selectedUserId.value = "";
+  await fetchGroup();
+};
+
+const removeMember = async (userId: string) => {
+  if (!group.value) return;
+  const newUserIds = group.value.users
+    .filter((u) => u.id !== userId)
+    .map((u) => u.id);
+  await $dropFetch(`/api/v1/admin/groups/${groupId}/members`, {
+    method: "PATCH",
+    body: { userIds: newUserIds },
+  });
+  await fetchGroup();
+};
+
+const saveRatings = async () => {
+  if (!group.value) return;
+  await $dropFetch(`/api/v1/admin/groups/${groupId}/ratings`, {
+    method: "PATCH",
+    body: {
+      bannedRatings: group.value.bannedAgeRatings.map((br) => ({
+        organization: br.organization,
+        rating: br.rating,
+      })),
+    },
+  });
+  await fetchGroup();
+};
+
+const addRating = async () => {
+  if (!group.value || !newRatingOrg.value || !newRatingValue.value) return;
+  group.value.bannedAgeRatings.push({
+    id: "",
+    organization: newRatingOrg.value,
+    rating: newRatingValue.value,
+  });
+  await saveRatings();
+  showAddRating.value = false;
+  newRatingOrg.value = "";
+  newRatingValue.value = "";
+};
+
+const removeRating = async (idx: number) => {
+  if (!group.value) return;
+  group.value.bannedAgeRatings.splice(idx, 1);
+  await saveRatings();
+};
+</script>

--- a/server/pages/admin/users/groups/[id].vue
+++ b/server/pages/admin/users/groups/[id].vue
@@ -67,8 +67,10 @@
           :key="member.id"
           class="flex items-center justify-between rounded-md bg-zinc-800/50 px-3 py-2"
         >
+          <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
           <span class="text-sm text-zinc-100">
             {{ member.displayName }}
+            <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
             <span class="text-zinc-400">({{ member.username }})</span>
           </span>
           <button
@@ -90,6 +92,7 @@
           <option value="" disabled>
             {{ $t("users.admin.groups.addMember") }}
           </option>
+          <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
           <option
             v-for="user in availableUsers"
             :key="user.id"
@@ -130,6 +133,7 @@
           :key="br.id"
           class="flex items-center gap-2"
         >
+          <!-- eslint-disable-next-line @intlify/vue-i18n/no-raw-text -->
           <span
             class="inline-flex items-center rounded-full bg-zinc-800 px-2.5 py-0.5 text-sm font-medium text-zinc-100"
           >
@@ -193,10 +197,7 @@
 
 <script setup lang="ts">
 import type { AuthMec } from "~/prisma/client/enums";
-import {
-  RATINGS_FOR_ORGANIZATION,
-  getAvailableRatings,
-} from "~/utils/ageRatings";
+import { getAvailableRatings } from "~/utils/ageRatings";
 import { AgeRatingOrganization } from "~/prisma/client/enums";
 
 useHead({ title: "Edit Group" });

--- a/server/pages/admin/users/groups/[id].vue
+++ b/server/pages/admin/users/groups/[id].vue
@@ -321,36 +321,34 @@ const removeMember = async (userId: string) => {
   await fetchGroup();
 };
 
-const saveRatings = async () => {
-  if (!group.value) return;
-  await $dropFetch(`/api/v1/admin/groups/${groupId}/ratings`, {
-    method: "PATCH",
-    body: {
-      bannedRatings: group.value.bannedAgeRatings.map((br) => ({
-        organization: br.organization,
-        rating: br.rating,
-      })),
-    },
-  });
-  await fetchGroup();
-};
-
 const addRating = async () => {
   if (!group.value || !newRatingOrg.value || !newRatingValue.value) return;
-  group.value.bannedAgeRatings.push({
-    id: "",
-    organization: newRatingOrg.value,
-    rating: newRatingValue.value,
+  const newRatings = [
+    ...group.value.bannedAgeRatings.map((br) => ({
+      organization: br.organization,
+      rating: br.rating,
+    })),
+    { organization: newRatingOrg.value, rating: newRatingValue.value },
+  ];
+  await $dropFetch(`/api/v1/admin/groups/${groupId}/ratings`, {
+    method: "PATCH",
+    body: { bannedRatings: newRatings },
   });
-  await saveRatings();
   showAddRating.value = false;
   newRatingOrg.value = "";
   newRatingValue.value = "";
+  await fetchGroup();
 };
 
 const removeRating = async (idx: number) => {
   if (!group.value) return;
-  group.value.bannedAgeRatings.splice(idx, 1);
-  await saveRatings();
+  const newRatings = group.value.bannedAgeRatings
+    .filter((_, i) => i !== idx)
+    .map((br) => ({ organization: br.organization, rating: br.rating }));
+  await $dropFetch(`/api/v1/admin/groups/${groupId}/ratings`, {
+    method: "PATCH",
+    body: { bannedRatings: newRatings },
+  });
+  await fetchGroup();
 };
 </script>

--- a/server/pages/admin/users/index.vue
+++ b/server/pages/admin/users/index.vue
@@ -22,6 +22,8 @@
         </NuxtLink>
       </div>
     </div>
+
+    <!-- Users Table -->
     <div class="mt-8 flow-root">
       <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
         <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
@@ -122,14 +124,6 @@
                     >
                       {{ $t("users.admin.delete") }}
                     </button>
-
-                    <!--
-                    <NuxtLink to="#" class="text-blue-600 hover:text-blue-500"
-                      >Edit<span class="sr-only"
-                        >, {{ user.displayName }}</span
-                      ></NuxtLink
-                    >
-                    -->
                   </td>
                 </tr>
               </tbody>
@@ -139,6 +133,202 @@
       </div>
     </div>
     <ModalDeleteUser v-model="userToDelete" />
+
+    <!-- Groups Section -->
+    <div class="mt-12">
+      <div class="sm:flex sm:items-center">
+        <div class="sm:flex-auto">
+          <h2 class="text-base font-semibold text-zinc-100">
+            {{ $t("users.admin.groups.title") }}
+          </h2>
+          <p class="mt-2 text-sm text-zinc-400">
+            {{ $t("users.admin.groups.description") }}
+          </p>
+        </div>
+        <div class="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
+          <button
+            class="block rounded-md bg-blue-600 px-3 py-2 text-center text-sm font-semibold text-white shadow-sm transition-all duration-200 hover:bg-blue-500 hover:scale-105 hover:shadow-lg active:scale-95 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+            @click="showCreateGroup = true"
+          >
+            {{ $t("users.admin.groups.createGroup") }}
+          </button>
+        </div>
+      </div>
+
+      <div class="mt-8 flow-root">
+        <div class="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
+          <div
+            class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8"
+          >
+            <div
+              class="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-900 shadow"
+            >
+              <table class="min-w-full divide-y divide-zinc-700">
+                <thead>
+                  <tr class="bg-zinc-800/50">
+                    <th
+                      scope="col"
+                      class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-zinc-100 sm:pl-6"
+                    >
+                      {{ $t("users.admin.groups.name") }}
+                    </th>
+                    <th
+                      scope="col"
+                      class="px-3 py-3.5 text-left text-sm font-semibold text-zinc-100"
+                    >
+                      {{ $t("users.admin.groups.descriptionField") }}
+                    </th>
+                    <th
+                      scope="col"
+                      class="px-3 py-3.5 text-left text-sm font-semibold text-zinc-100"
+                    >
+                      {{ $t("users.admin.groups.members") }}
+                    </th>
+                    <th
+                      scope="col"
+                      class="px-3 py-3.5 text-left text-sm font-semibold text-zinc-100"
+                    >
+                      {{ $t("users.admin.groups.bannedRatings") }}
+                    </th>
+                    <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
+                      <span class="sr-only">Actions</span>
+                    </th>
+                  </tr>
+                </thead>
+                <tbody class="divide-y divide-zinc-700">
+                  <tr
+                    v-for="group in groups"
+                    :key="group.id"
+                    class="hover:bg-zinc-800/50 transition-colors duration-150"
+                  >
+                    <td
+                      class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-zinc-100 sm:pl-6"
+                    >
+                      {{ group.name }}
+                    </td>
+                    <td
+                      class="whitespace-nowrap px-3 py-4 text-sm text-zinc-400"
+                    >
+                      {{ group.description || "-" }}
+                    </td>
+                    <td
+                      class="whitespace-nowrap px-3 py-4 text-sm text-zinc-400"
+                    >
+                      {{ group._count.users }}
+                    </td>
+                    <td
+                      class="whitespace-nowrap px-3 py-4 text-sm text-zinc-400"
+                    >
+                      {{ group._count.bannedAgeRatings }}
+                    </td>
+                    <td
+                      class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6 space-x-2"
+                    >
+                      <NuxtLink
+                        :to="`/admin/users/groups/${group.id}`"
+                        class="text-blue-400 hover:text-blue-300"
+                      >
+                        {{ $t("common.edit") }}
+                      </NuxtLink>
+                      <button
+                        class="text-red-400 hover:text-red-300"
+                        @click="groupToDelete = group"
+                      >
+                        {{ $t("users.admin.groups.deleteGroup") }}
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Create Group Modal -->
+    <div
+      v-if="showCreateGroup"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/70"
+      @click.self="showCreateGroup = false"
+    >
+      <div
+        class="rounded-lg border border-zinc-700 bg-zinc-900 p-6 shadow-xl w-full max-w-md"
+      >
+        <h2 class="text-lg font-semibold text-zinc-100 mb-4">
+          {{ $t("users.admin.groups.createGroup") }}
+        </h2>
+        <div class="space-y-4">
+          <div>
+            <label class="text-sm/6 font-medium text-zinc-100">
+              {{ $t("users.admin.groups.name") }}
+            </label>
+            <input
+              v-model="newGroupName"
+              type="text"
+              class="mt-1 block w-full rounded-md bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline outline-1 -outline-offset-1 outline-zinc-700 focus:outline-blue-600"
+            />
+          </div>
+          <div>
+            <label class="text-sm/6 font-medium text-zinc-100">
+              {{ $t("users.admin.groups.descriptionField") }}
+            </label>
+            <input
+              v-model="newGroupDescription"
+              type="text"
+              class="mt-1 block w-full rounded-md bg-zinc-800 px-3 py-1.5 text-sm text-zinc-100 outline outline-1 -outline-offset-1 outline-zinc-700 focus:outline-blue-600"
+            />
+          </div>
+          <div class="flex justify-end gap-2">
+            <button
+              class="rounded-md px-3 py-2 text-sm font-semibold text-zinc-400 hover:text-zinc-300"
+              @click="showCreateGroup = false"
+            >
+              {{ $t("cancel") }}
+            </button>
+            <button
+              class="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-500"
+              :disabled="newGroupName.length < 2"
+              @click="createGroup"
+            >
+              {{ $t("users.admin.groups.createGroup") }}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <!-- Delete Group Confirm Modal -->
+    <div
+      v-if="groupToDelete"
+      class="fixed inset-0 z-50 flex items-center justify-center bg-zinc-950/70"
+      @click.self="groupToDelete = undefined"
+    >
+      <div
+        class="rounded-lg border border-zinc-700 bg-zinc-900 p-6 shadow-xl w-full max-w-md"
+      >
+        <h2 class="text-lg font-semibold text-zinc-100 mb-4">
+          {{ $t("users.admin.groups.deleteGroup") }}
+        </h2>
+        <p class="text-sm text-zinc-400 mb-4">
+          {{ $t("users.admin.groups.deleteConfirm") }}
+        </p>
+        <div class="flex justify-end gap-2">
+          <button
+            class="rounded-md px-3 py-2 text-sm font-semibold text-zinc-400 hover:text-zinc-300"
+            @click="groupToDelete = undefined"
+          >
+            {{ $t("cancel") }}
+          </button>
+          <button
+            class="rounded-md bg-red-600 px-3 py-2 text-sm font-semibold text-white hover:bg-red-500"
+            @click="deleteGroup"
+          >
+            {{ $t("users.admin.groups.deleteGroup") }}
+          </button>
+        </div>
+      </div>
+    </div>
   </div>
 </template>
 
@@ -162,6 +352,45 @@ if (!users.value) {
 }
 
 const userToDelete = ref();
-
 const setUserToDelete = (user: UserModel) => (userToDelete.value = user);
+
+// Groups
+interface GroupListItem {
+  id: string;
+  name: string;
+  description: string;
+  _count: { users: number; bannedAgeRatings: number };
+}
+
+const groups = ref<GroupListItem[]>([]);
+const showCreateGroup = ref(false);
+const newGroupName = ref("");
+const newGroupDescription = ref("");
+const groupToDelete = ref<GroupListItem | undefined>();
+
+const fetchGroups = async () => {
+  groups.value = await $dropFetch<GroupListItem[]>("/api/v1/admin/groups");
+};
+
+await fetchGroups();
+
+const createGroup = async () => {
+  await $dropFetch("/api/v1/admin/groups", {
+    method: "POST",
+    body: { name: newGroupName.value, description: newGroupDescription.value },
+  });
+  showCreateGroup.value = false;
+  newGroupName.value = "";
+  newGroupDescription.value = "";
+  await fetchGroups();
+};
+
+const deleteGroup = async () => {
+  if (!groupToDelete.value) return;
+  await $dropFetch(`/api/v1/admin/groups/${groupToDelete.value.id}`, {
+    method: "DELETE",
+  });
+  groupToDelete.value = undefined;
+  await fetchGroups();
+};
 </script>

--- a/server/pages/admin/users/index.vue
+++ b/server/pages/admin/users/index.vue
@@ -191,7 +191,9 @@
                       {{ $t("users.admin.groups.bannedRatings") }}
                     </th>
                     <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
-                      <span class="sr-only">Actions</span>
+                      <span class="sr-only">
+                        {{ $t("users.admin.srEditLabel") }}
+                      </span>
                     </th>
                   </tr>
                 </thead>

--- a/server/prisma/migrations/20260726041153_add_user_groups/migration.sql
+++ b/server/prisma/migrations/20260726041153_add_user_groups/migration.sql
@@ -1,0 +1,58 @@
+-- DropIndex
+DROP INDEX "Game_mName_idx";
+
+-- DropIndex
+DROP INDEX "GameTag_name_idx";
+
+-- CreateTable
+CREATE TABLE "UserGroup" (
+    "id" TEXT NOT NULL,
+    "name" TEXT NOT NULL,
+    "description" TEXT NOT NULL DEFAULT '',
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "UserGroup_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "BannedAgeRating" (
+    "id" TEXT NOT NULL,
+    "organization" "AgeRatingOrganization" NOT NULL,
+    "rating" TEXT NOT NULL,
+    "userGroupId" TEXT NOT NULL,
+
+    CONSTRAINT "BannedAgeRating_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_UserToUserGroup" (
+    "A" TEXT NOT NULL,
+    "B" TEXT NOT NULL,
+
+    CONSTRAINT "_UserToUserGroup_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserGroup_name_key" ON "UserGroup"("name");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "BannedAgeRating_userGroupId_organization_rating_key" ON "BannedAgeRating"("userGroupId", "organization", "rating");
+
+-- CreateIndex
+CREATE INDEX "_UserToUserGroup_B_index" ON "_UserToUserGroup"("B");
+
+-- CreateIndex
+CREATE INDEX "Game_mName_idx" ON "Game" USING GIST ("mName" gist_trgm_ops(siglen=32));
+
+-- CreateIndex
+CREATE INDEX "GameTag_name_idx" ON "GameTag" USING GIST ("name" gist_trgm_ops(siglen=32));
+
+-- AddForeignKey
+ALTER TABLE "BannedAgeRating" ADD CONSTRAINT "BannedAgeRating_userGroupId_fkey" FOREIGN KEY ("userGroupId") REFERENCES "UserGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_UserToUserGroup" ADD CONSTRAINT "_UserToUserGroup_A_fkey" FOREIGN KEY ("A") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_UserToUserGroup" ADD CONSTRAINT "_UserToUserGroup_B_fkey" FOREIGN KEY ("B") REFERENCES "UserGroup"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/server/prisma/models/group.prisma
+++ b/server/prisma/models/group.prisma
@@ -1,0 +1,23 @@
+model UserGroup {
+  id          String @id @default(uuid())
+  name        String @unique
+  description String @default("")
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  users            User[]
+  bannedAgeRatings BannedAgeRating[]
+}
+
+model BannedAgeRating {
+  id String @id @default(uuid())
+
+  organization AgeRatingOrganization
+  rating       String
+
+  userGroup   UserGroup @relation(fields: [userGroupId], references: [id], onDelete: Cascade)
+  userGroupId String
+
+  @@unique([userGroupId, organization, rating], name: "groupRatingKey")
+}

--- a/server/prisma/models/user.prisma
+++ b/server/prisma/models/user.prisma
@@ -22,6 +22,8 @@ model User {
     saves       SaveSlot[]
     screenshots Screenshot[]
     playtime    Playtime[]
+
+    groups UserGroup[]
 }
 
 model Notification {

--- a/server/server/api/v1/admin/groups/[id]/index.delete.ts
+++ b/server/server/api/v1/admin/groups/[id]/index.delete.ts
@@ -11,6 +11,7 @@ export default defineEventHandler(async (h3) => {
   if (!group)
     throw createError({ statusCode: 404, message: "Group not found" });
 
+  // SAFETY: existence verified above via findUnique
   // eslint-disable-next-line drop/no-prisma-delete
   await prisma.userGroup.delete({ where: { id } });
 

--- a/server/server/api/v1/admin/groups/[id]/index.delete.ts
+++ b/server/server/api/v1/admin/groups/[id]/index.delete.ts
@@ -1,0 +1,18 @@
+import aclManager from "~/server/internal/acls";
+import prisma from "~/server/internal/db/database";
+
+export default defineEventHandler(async (h3) => {
+  const allowed = await aclManager.allowSystemACL(h3, ["user:delete"]);
+  if (!allowed) throw createError({ statusCode: 403 });
+
+  const id = getRouterParam(h3, "id")!;
+
+  const group = await prisma.userGroup.findUnique({ where: { id } });
+  if (!group)
+    throw createError({ statusCode: 404, message: "Group not found" });
+
+  // eslint-disable-next-line drop/no-prisma-delete
+  await prisma.userGroup.delete({ where: { id } });
+
+  return { success: true };
+});

--- a/server/server/api/v1/admin/groups/[id]/index.get.ts
+++ b/server/server/api/v1/admin/groups/[id]/index.get.ts
@@ -1,0 +1,28 @@
+import aclManager from "~/server/internal/acls";
+import prisma from "~/server/internal/db/database";
+
+export default defineEventHandler(async (h3) => {
+  const allowed = await aclManager.allowSystemACL(h3, ["user:read"]);
+  if (!allowed) throw createError({ statusCode: 403 });
+
+  const id = getRouterParam(h3, "id")!;
+
+  const group = await prisma.userGroup.findUnique({
+    where: { id },
+    include: {
+      users: {
+        select: {
+          id: true,
+          username: true,
+          displayName: true,
+        },
+      },
+      bannedAgeRatings: true,
+    },
+  });
+
+  if (!group)
+    throw createError({ statusCode: 404, message: "Group not found" });
+
+  return group;
+});

--- a/server/server/api/v1/admin/groups/[id]/index.patch.ts
+++ b/server/server/api/v1/admin/groups/[id]/index.patch.ts
@@ -28,6 +28,7 @@ export default defineEventHandler(async (h3) => {
       message: "Group name already exists",
     });
 
+  // SAFETY: existence verified above via findUnique
   // eslint-disable-next-line drop/no-prisma-delete
   const group = await prisma.userGroup.update({
     where: { id },

--- a/server/server/api/v1/admin/groups/[id]/index.patch.ts
+++ b/server/server/api/v1/admin/groups/[id]/index.patch.ts
@@ -25,6 +25,7 @@ export default defineEventHandler(async (h3) => {
   if (nameTaken)
     throw createError({ statusCode: 400, message: "Group name already exists" });
 
+  // eslint-disable-next-line drop/no-prisma-delete
   const group = await prisma.userGroup.update({
     where: { id },
     data: {

--- a/server/server/api/v1/admin/groups/[id]/index.patch.ts
+++ b/server/server/api/v1/admin/groups/[id]/index.patch.ts
@@ -23,7 +23,10 @@ export default defineEventHandler(async (h3) => {
     where: { name: body.name, id: { not: id } },
   });
   if (nameTaken)
-    throw createError({ statusCode: 400, message: "Group name already exists" });
+    throw createError({
+      statusCode: 400,
+      message: "Group name already exists",
+    });
 
   // eslint-disable-next-line drop/no-prisma-delete
   const group = await prisma.userGroup.update({

--- a/server/server/api/v1/admin/groups/[id]/index.patch.ts
+++ b/server/server/api/v1/admin/groups/[id]/index.patch.ts
@@ -1,0 +1,37 @@
+import { type } from "arktype";
+import { readDropValidatedBody, throwingArktype } from "~/server/arktype";
+import aclManager from "~/server/internal/acls";
+import prisma from "~/server/internal/db/database";
+
+const PatchGroup = type({
+  name: "2 <= string <= 50",
+  description: "string = ''",
+}).configure(throwingArktype);
+
+export default defineEventHandler(async (h3) => {
+  const allowed = await aclManager.allowSystemACL(h3, ["user:delete"]);
+  if (!allowed) throw createError({ statusCode: 403 });
+
+  const id = getRouterParam(h3, "id")!;
+  const body = await readDropValidatedBody(h3, PatchGroup);
+
+  const existing = await prisma.userGroup.findUnique({ where: { id } });
+  if (!existing)
+    throw createError({ statusCode: 404, message: "Group not found" });
+
+  const nameTaken = await prisma.userGroup.findFirst({
+    where: { name: body.name, id: { not: id } },
+  });
+  if (nameTaken)
+    throw createError({ statusCode: 400, message: "Group name already exists" });
+
+  const group = await prisma.userGroup.update({
+    where: { id },
+    data: {
+      name: body.name,
+      description: body.description,
+    },
+  });
+
+  return group;
+});

--- a/server/server/api/v1/admin/groups/[id]/members.patch.ts
+++ b/server/server/api/v1/admin/groups/[id]/members.patch.ts
@@ -18,6 +18,7 @@ export default defineEventHandler(async (h3) => {
   if (!group)
     throw createError({ statusCode: 404, message: "Group not found" });
 
+  // eslint-disable-next-line drop/no-prisma-delete
   await prisma.userGroup.update({
     where: { id },
     data: {

--- a/server/server/api/v1/admin/groups/[id]/members.patch.ts
+++ b/server/server/api/v1/admin/groups/[id]/members.patch.ts
@@ -18,6 +18,7 @@ export default defineEventHandler(async (h3) => {
   if (!group)
     throw createError({ statusCode: 404, message: "Group not found" });
 
+  // SAFETY: existence verified above via findUnique
   // eslint-disable-next-line drop/no-prisma-delete
   await prisma.userGroup.update({
     where: { id },
@@ -26,7 +27,7 @@ export default defineEventHandler(async (h3) => {
     },
   });
 
-  return await prisma.userGroup.findUnique({
+  const updated = await prisma.userGroup.findUnique({
     where: { id },
     include: {
       users: {
@@ -38,4 +39,6 @@ export default defineEventHandler(async (h3) => {
       },
     },
   });
+
+  return updated;
 });

--- a/server/server/api/v1/admin/groups/[id]/members.patch.ts
+++ b/server/server/api/v1/admin/groups/[id]/members.patch.ts
@@ -1,0 +1,40 @@
+import { type } from "arktype";
+import { readDropValidatedBody, throwingArktype } from "~/server/arktype";
+import aclManager from "~/server/internal/acls";
+import prisma from "~/server/internal/db/database";
+
+const PatchMembers = type({
+  userIds: "string[]",
+}).configure(throwingArktype);
+
+export default defineEventHandler(async (h3) => {
+  const allowed = await aclManager.allowSystemACL(h3, ["user:delete"]);
+  if (!allowed) throw createError({ statusCode: 403 });
+
+  const id = getRouterParam(h3, "id")!;
+  const body = await readDropValidatedBody(h3, PatchMembers);
+
+  const group = await prisma.userGroup.findUnique({ where: { id } });
+  if (!group)
+    throw createError({ statusCode: 404, message: "Group not found" });
+
+  await prisma.userGroup.update({
+    where: { id },
+    data: {
+      users: { set: body.userIds.map((uid) => ({ id: uid })) },
+    },
+  });
+
+  return await prisma.userGroup.findUnique({
+    where: { id },
+    include: {
+      users: {
+        select: {
+          id: true,
+          username: true,
+          displayName: true,
+        },
+      },
+    },
+  });
+});

--- a/server/server/api/v1/admin/groups/[id]/ratings.patch.ts
+++ b/server/server/api/v1/admin/groups/[id]/ratings.patch.ts
@@ -1,0 +1,63 @@
+import { type } from "arktype";
+import type { AgeRatingOrganization } from "~/prisma/client/enums";
+import { readDropValidatedBody, throwingArktype } from "~/server/arktype";
+import aclManager from "~/server/internal/acls";
+import prisma from "~/server/internal/db/database";
+import {
+  getAvailableRatings,
+  RATINGS_FOR_ORGANIZATION,
+} from "~/utils/ageRatings";
+
+const PatchRatings = type({
+  bannedRatings: type({
+    organization: "string",
+    rating: "string",
+  }).array(),
+}).configure(throwingArktype);
+
+export default defineEventHandler(async (h3) => {
+  const allowed = await aclManager.allowSystemACL(h3, ["user:delete"]);
+  if (!allowed) throw createError({ statusCode: 403 });
+
+  const id = getRouterParam(h3, "id")!;
+  const body = await readDropValidatedBody(h3, PatchRatings);
+
+  const group = await prisma.userGroup.findUnique({ where: { id } });
+  if (!group)
+    throw createError({ statusCode: 404, message: "Group not found" });
+
+  for (const br of body.bannedRatings) {
+    if (!(br.organization in RATINGS_FOR_ORGANIZATION)) {
+      throw createError({
+        statusCode: 400,
+        message: `Invalid organization: ${br.organization}`,
+      });
+    }
+    const validRatings = getAvailableRatings(
+      br.organization as AgeRatingOrganization,
+    );
+    if (!validRatings.includes(br.rating)) {
+      throw createError({
+        statusCode: 400,
+        message: `Invalid rating "${br.rating}" for ${br.organization}`,
+      });
+    }
+  }
+
+  await prisma.$transaction([
+    prisma.bannedAgeRating.deleteMany({
+      where: { userGroupId: id },
+    }),
+    prisma.bannedAgeRating.createMany({
+      data: body.bannedRatings.map((br) => ({
+        userGroupId: id,
+        organization: br.organization as AgeRatingOrganization,
+        rating: br.rating,
+      })),
+    }),
+  ]);
+
+  return await prisma.bannedAgeRating.findMany({
+    where: { userGroupId: id },
+  });
+});

--- a/server/server/api/v1/admin/groups/[id]/ratings.patch.ts
+++ b/server/server/api/v1/admin/groups/[id]/ratings.patch.ts
@@ -57,7 +57,9 @@ export default defineEventHandler(async (h3) => {
     }),
   ]);
 
-  return await prisma.bannedAgeRating.findMany({
+  const ratings = await prisma.bannedAgeRating.findMany({
     where: { userGroupId: id },
   });
+
+  return ratings;
 });

--- a/server/server/api/v1/admin/groups/index.get.ts
+++ b/server/server/api/v1/admin/groups/index.get.ts
@@ -1,0 +1,21 @@
+import aclManager from "~/server/internal/acls";
+import prisma from "~/server/internal/db/database";
+
+export default defineEventHandler(async (h3) => {
+  const allowed = await aclManager.allowSystemACL(h3, ["user:read"]);
+  if (!allowed) throw createError({ statusCode: 403 });
+
+  const groups = await prisma.userGroup.findMany({
+    include: {
+      _count: {
+        select: {
+          users: true,
+          bannedAgeRatings: true,
+        },
+      },
+    },
+    orderBy: { name: "asc" },
+  });
+
+  return groups;
+});

--- a/server/server/api/v1/admin/groups/index.post.ts
+++ b/server/server/api/v1/admin/groups/index.post.ts
@@ -18,7 +18,10 @@ export default defineEventHandler(async (h3) => {
     where: { name: body.name },
   });
   if (existing)
-    throw createError({ statusCode: 400, message: "Group name already exists" });
+    throw createError({
+      statusCode: 400,
+      message: "Group name already exists",
+    });
 
   const group = await prisma.userGroup.create({
     data: {

--- a/server/server/api/v1/admin/groups/index.post.ts
+++ b/server/server/api/v1/admin/groups/index.post.ts
@@ -1,0 +1,31 @@
+import { type } from "arktype";
+import { readDropValidatedBody, throwingArktype } from "~/server/arktype";
+import aclManager from "~/server/internal/acls";
+import prisma from "~/server/internal/db/database";
+
+const CreateGroup = type({
+  name: "2 <= string <= 50",
+  description: "string = ''",
+}).configure(throwingArktype);
+
+export default defineEventHandler(async (h3) => {
+  const allowed = await aclManager.allowSystemACL(h3, ["user:delete"]);
+  if (!allowed) throw createError({ statusCode: 403 });
+
+  const body = await readDropValidatedBody(h3, CreateGroup);
+
+  const existing = await prisma.userGroup.findUnique({
+    where: { name: body.name },
+  });
+  if (existing)
+    throw createError({ statusCode: 400, message: "Group name already exists" });
+
+  const group = await prisma.userGroup.create({
+    data: {
+      name: body.name,
+      description: body.description,
+    },
+  });
+
+  return group;
+});

--- a/server/server/api/v1/client/collection/default/entry.post.ts
+++ b/server/server/api/v1/client/collection/default/entry.post.ts
@@ -1,5 +1,7 @@
 import { defineClientEventHandler } from "~/server/internal/clients/event-handler";
+import prisma from "~/server/internal/db/database";
 import userLibraryManager from "~/server/internal/userlibrary";
+import { getAgeRestrictionFilter } from "~/server/internal/utils/ageRestrictions";
 
 export default defineClientEventHandler(async (h3, { fetchUser }) => {
   const user = await fetchUser();
@@ -8,6 +10,15 @@ export default defineClientEventHandler(async (h3, { fetchUser }) => {
   const gameId = body.id;
   if (!gameId)
     throw createError({ statusCode: 400, statusMessage: "Game ID required" });
+
+  const ageFilter = await getAgeRestrictionFilter(user.id, user.admin);
+  if (ageFilter) {
+    const allowed = await prisma.game.count({
+      where: { id: gameId, ...ageFilter },
+    });
+    if (allowed === 0)
+      throw createError({ statusCode: 404, statusMessage: "Game not found" });
+  }
 
   // Add the game to the default collection
   await userLibraryManager.libraryAdd(gameId, user.id);

--- a/server/server/api/v1/client/user/library.get.ts
+++ b/server/server/api/v1/client/user/library.get.ts
@@ -1,8 +1,10 @@
 import { defineClientEventHandler } from "~/server/internal/clients/event-handler";
 import userLibraryManager from "~/server/internal/userlibrary";
+import { getAgeRestrictionFilter } from "~/server/internal/utils/ageRestrictions";
 
 export default defineClientEventHandler(async (_h3, { fetchUser }) => {
   const user = await fetchUser();
-  const library = await userLibraryManager.fetchLibrary(user.id);
+  const ageFilter = await getAgeRestrictionFilter(user.id, user.admin);
+  const library = await userLibraryManager.fetchLibrary(user.id, ageFilter);
   return library.entries.map((e) => e.game);
 });

--- a/server/server/api/v1/collection/[id]/entry.post.ts
+++ b/server/server/api/v1/collection/[id]/entry.post.ts
@@ -1,9 +1,11 @@
 import aclManager from "~/server/internal/acls";
+import prisma from "~/server/internal/db/database";
 import userLibraryManager from "~/server/internal/userlibrary";
+import { getAgeRestrictionFilter } from "~/server/internal/utils/ageRestrictions";
 
 export default defineEventHandler(async (h3) => {
-  const userId = await aclManager.getUserIdACL(h3, ["collections:add"]);
-  if (!userId)
+  const user = await aclManager.getUserACL(h3, ["collections:add"]);
+  if (!user)
     throw createError({
       statusCode: 403,
     });
@@ -20,5 +22,16 @@ export default defineEventHandler(async (h3) => {
   if (!gameId)
     throw createError({ statusCode: 400, statusMessage: "Game ID required" });
 
-  return await userLibraryManager.collectionAdd(gameId, id, userId);
+  const ageFilter = await getAgeRestrictionFilter(user.id, user.admin);
+  if (ageFilter) {
+    const allowed = await prisma.game.count({
+      where: { id: gameId, ...ageFilter },
+    });
+    if (allowed === 0)
+      throw createError({ statusCode: 404, statusMessage: "Game not found" });
+  }
+
+  const result = await userLibraryManager.collectionAdd(gameId, id, user.id);
+
+  return result;
 });

--- a/server/server/api/v1/collection/[id]/index.get.ts
+++ b/server/server/api/v1/collection/[id]/index.get.ts
@@ -1,9 +1,10 @@
 import aclManager from "~/server/internal/acls";
 import userLibraryManager from "~/server/internal/userlibrary";
+import { getAgeRestrictionFilter } from "~/server/internal/utils/ageRestrictions";
 
 export default defineEventHandler(async (h3) => {
-  const userId = await aclManager.getUserIdACL(h3, ["collections:read"]);
-  if (!userId)
+  const user = await aclManager.getUserACL(h3, ["collections:read"]);
+  if (!user)
     throw createError({
       statusCode: 403,
       statusMessage: "Requires authentication",
@@ -16,9 +17,11 @@ export default defineEventHandler(async (h3) => {
       statusMessage: "ID required in route params",
     });
 
+  const ageFilter = await getAgeRestrictionFilter(user.id, user.admin);
+
   // Fetch specific collection
   // Will not return the default collection
-  const collection = await userLibraryManager.fetchCollection(id);
+  const collection = await userLibraryManager.fetchCollection(id, ageFilter);
   if (!collection)
     throw createError({
       statusCode: 404,
@@ -26,7 +29,7 @@ export default defineEventHandler(async (h3) => {
     });
 
   // Verify user owns this collection
-  if (collection.userId !== userId)
+  if (collection.userId !== user.id)
     throw createError({
       statusCode: 403,
       statusMessage: "Not authorized to access this collection",

--- a/server/server/api/v1/collection/default/entry.post.ts
+++ b/server/server/api/v1/collection/default/entry.post.ts
@@ -1,9 +1,11 @@
 import aclManager from "~/server/internal/acls";
+import prisma from "~/server/internal/db/database";
 import userLibraryManager from "~/server/internal/userlibrary";
+import { getAgeRestrictionFilter } from "~/server/internal/utils/ageRestrictions";
 
 export default defineEventHandler(async (h3) => {
-  const userId = await aclManager.getUserIdACL(h3, ["library:add"]);
-  if (!userId)
+  const user = await aclManager.getUserACL(h3, ["library:add"]);
+  if (!user)
     throw createError({
       statusCode: 403,
       statusMessage: "Requires authentication",
@@ -14,7 +16,16 @@ export default defineEventHandler(async (h3) => {
   if (!gameId)
     throw createError({ statusCode: 400, statusMessage: "Game ID required" });
 
+  const ageFilter = await getAgeRestrictionFilter(user.id, user.admin);
+  if (ageFilter) {
+    const allowed = await prisma.game.count({
+      where: { id: gameId, ...ageFilter },
+    });
+    if (allowed === 0)
+      throw createError({ statusCode: 404, statusMessage: "Game not found" });
+  }
+
   // Add the game to the default collection
-  await userLibraryManager.libraryAdd(gameId, userId);
+  await userLibraryManager.libraryAdd(gameId, user.id);
   return {};
 });

--- a/server/server/api/v1/collection/default/index.get.ts
+++ b/server/server/api/v1/collection/default/index.get.ts
@@ -1,15 +1,17 @@
 import aclManager from "~/server/internal/acls";
 import userLibraryManager from "~/server/internal/userlibrary";
+import { getAgeRestrictionFilter } from "~/server/internal/utils/ageRestrictions";
 
 export default defineEventHandler(async (h3) => {
-  const userId = await aclManager.getUserIdACL(h3, ["collections:read"]);
-  if (!userId)
+  const user = await aclManager.getUserACL(h3, ["collections:read"]);
+  if (!user)
     throw createError({
       statusCode: 403,
       statusMessage: "Requires authentication",
     });
 
-  const collection = await userLibraryManager.fetchLibrary(userId);
+  const ageFilter = await getAgeRestrictionFilter(user.id, user.admin);
+  const collection = await userLibraryManager.fetchLibrary(user.id, ageFilter);
 
   return collection;
 });

--- a/server/server/api/v1/collection/index.get.ts
+++ b/server/server/api/v1/collection/index.get.ts
@@ -1,13 +1,18 @@
 import aclManager from "~/server/internal/acls";
 import userLibraryManager from "~/server/internal/userlibrary";
+import { getAgeRestrictionFilter } from "~/server/internal/utils/ageRestrictions";
 
 export default defineEventHandler(async (h3) => {
-  const userId = await aclManager.getUserIdACL(h3, ["collections:read"]);
-  if (!userId)
+  const user = await aclManager.getUserACL(h3, ["collections:read"]);
+  if (!user)
     throw createError({
       statusCode: 403,
     });
 
-  const collections = await userLibraryManager.fetchCollections(userId);
+  const ageFilter = await getAgeRestrictionFilter(user.id, user.admin);
+  const collections = await userLibraryManager.fetchCollections(
+    user.id,
+    ageFilter,
+  );
   return collections;
 });

--- a/server/server/api/v1/games/[id]/index.get.ts
+++ b/server/server/api/v1/games/[id]/index.get.ts
@@ -14,6 +14,16 @@ export default defineEventHandler(async (h3) => {
       statusMessage: "Missing gameId in route params (somehow...?)",
     });
 
+  // Check age restrictions before the heavy fetch
+  const ageFilter = await getAgeRestrictionFilter(user.id, user.admin);
+  if (ageFilter) {
+    const allowed = await prisma.game.count({
+      where: { id: gameId, ...ageFilter },
+    });
+    if (allowed === 0)
+      throw createError({ statusCode: 404, statusMessage: "Game not found" });
+  }
+
   const game = await prisma.game.findUnique({
     where: { id: gameId },
     include: {
@@ -52,15 +62,6 @@ export default defineEventHandler(async (h3) => {
 
   if (!game)
     throw createError({ statusCode: 404, statusMessage: "Game not found" });
-
-  const ageFilter = await getAgeRestrictionFilter(user.id, user.admin);
-  if (ageFilter) {
-    const allowed = await prisma.game.count({
-      where: { id: gameId, ...ageFilter },
-    });
-    if (allowed === 0)
-      throw createError({ statusCode: 404, statusMessage: "Game not found" });
-  }
 
   const rating = await prisma.gameRating.aggregate({
     where: {

--- a/server/server/api/v1/games/[id]/index.get.ts
+++ b/server/server/api/v1/games/[id]/index.get.ts
@@ -1,10 +1,11 @@
 import aclManager from "~/server/internal/acls";
 import prisma from "~/server/internal/db/database";
 import gameSizeManager from "~/server/internal/gamesize";
+import { getAgeRestrictionFilter } from "~/server/internal/utils/ageRestrictions";
 
 export default defineEventHandler(async (h3) => {
-  const userId = await aclManager.getUserIdACL(h3, ["store:read"]);
-  if (!userId) throw createError({ statusCode: 403 });
+  const user = await aclManager.getUserACL(h3, ["store:read"]);
+  if (!user) throw createError({ statusCode: 403 });
 
   const gameId = getRouterParam(h3, "id");
   if (!gameId)
@@ -51,6 +52,15 @@ export default defineEventHandler(async (h3) => {
 
   if (!game)
     throw createError({ statusCode: 404, statusMessage: "Game not found" });
+
+  const ageFilter = await getAgeRestrictionFilter(user.id, user.admin);
+  if (ageFilter) {
+    const allowed = await prisma.game.count({
+      where: { id: gameId, ...ageFilter },
+    });
+    if (allowed === 0)
+      throw createError({ statusCode: 404, statusMessage: "Game not found" });
+  }
 
   const rating = await prisma.gameRating.aggregate({
     where: {

--- a/server/server/api/v1/store/featured.get.ts
+++ b/server/server/api/v1/store/featured.get.ts
@@ -1,13 +1,17 @@
 import aclManager from "~/server/internal/acls";
 import prisma from "~/server/internal/db/database";
+import { getAgeRestrictionFilter } from "~/server/internal/utils/ageRestrictions";
 
 export default defineEventHandler(async (h3) => {
-  const userId = await aclManager.getUserACL(h3, ["store:read"]);
-  if (!userId) throw createError({ statusCode: 403 });
+  const user = await aclManager.getUserACL(h3, ["store:read"]);
+  if (!user) throw createError({ statusCode: 403 });
+
+  const ageFilter = await getAgeRestrictionFilter(user.id, user.admin);
 
   const games = await prisma.game.findMany({
     where: {
       featured: true,
+      ...ageFilter,
     },
     select: {
       id: true,

--- a/server/server/api/v1/store/index.get.ts
+++ b/server/server/api/v1/store/index.get.ts
@@ -4,6 +4,7 @@ import { GameType } from "~/prisma/client/enums";
 import aclManager from "~/server/internal/acls";
 import prisma from "~/server/internal/db/database";
 import { parsePlatform } from "~/server/internal/utils/parseplatform";
+import { getAgeRestrictionFilter } from "~/server/internal/utils/ageRestrictions";
 
 const StoreRead = type({
   skip: type("string")
@@ -24,8 +25,9 @@ const StoreRead = type({
 });
 
 export default defineEventHandler(async (h3) => {
-  const userId = await aclManager.getUserIdACL(h3, ["store:read"]);
-  if (!userId) throw createError({ statusCode: 403 });
+  const user = await aclManager.getUserACL(h3, ["store:read"]);
+  if (!user) throw createError({ statusCode: 403 });
+  const userId = user.id;
 
   const query = getQuery(h3);
   const options = StoreRead(query);
@@ -116,10 +118,13 @@ export default defineEventHandler(async (h3) => {
    * Query
    */
 
+  const ageFilter = await getAgeRestrictionFilter(userId, user.admin);
+
   const finalFilter: Prisma.GameWhereInput = {
     ...tagFilter,
     ...platformFilter,
     ...companyFilter,
+    ...ageFilter,
     type: GameType.Game,
   };
 

--- a/server/server/internal/auth/oidc/index.ts
+++ b/server/server/internal/auth/oidc/index.ts
@@ -507,6 +507,7 @@ export class OIDCManager {
     if (oidcGroups === undefined) return;
 
     if (oidcGroups.length === 0) {
+      // eslint-disable-next-line drop/no-prisma-delete
       await prisma.user.update({
         where: { id: userId },
         data: { groups: { set: [] } },
@@ -519,6 +520,7 @@ export class OIDCManager {
       select: { id: true },
     });
 
+    // eslint-disable-next-line drop/no-prisma-delete
     await prisma.user.update({
       where: { id: userId },
       data: {

--- a/server/server/internal/auth/oidc/index.ts
+++ b/server/server/internal/auth/oidc/index.ts
@@ -503,7 +503,10 @@ export class OIDCManager {
     userId: string,
     oidcGroups: string[] | undefined,
   ) {
-    if (!oidcGroups || oidcGroups.length === 0) {
+    // If the IdP didn't include the groups claim, don't touch membership
+    if (oidcGroups === undefined) return;
+
+    if (oidcGroups.length === 0) {
       await prisma.user.update({
         where: { id: userId },
         data: { groups: { set: [] } },

--- a/server/server/internal/auth/oidc/index.ts
+++ b/server/server/internal/auth/oidc/index.ts
@@ -407,7 +407,10 @@ export class OIDCManager {
       },
     });
 
-    if (existingAuthMek) return existingAuthMek.user;
+    if (existingAuthMek) {
+      await this.syncUserGroups(existingAuthMek.user.id, userinfo.groups);
+      return existingAuthMek.user;
+    }
 
     const username = userinfo[this.usernameClaim]?.toString();
     if (!username)
@@ -492,7 +495,33 @@ export class OIDCManager {
       },
     });
 
+    await this.syncUserGroups(created.user.id, userinfo.groups);
     return created.user;
+  }
+
+  private async syncUserGroups(
+    userId: string,
+    oidcGroups: string[] | undefined,
+  ) {
+    if (!oidcGroups || oidcGroups.length === 0) {
+      await prisma.user.update({
+        where: { id: userId },
+        data: { groups: { set: [] } },
+      });
+      return;
+    }
+
+    const matchingGroups = await prisma.userGroup.findMany({
+      where: { name: { in: oidcGroups } },
+      select: { id: true },
+    });
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: {
+        groups: { set: matchingGroups.map((g) => ({ id: g.id })) },
+      },
+    });
   }
 
   /**

--- a/server/server/internal/auth/oidc/index.ts
+++ b/server/server/internal/auth/oidc/index.ts
@@ -506,26 +506,24 @@ export class OIDCManager {
     // If the IdP didn't include the groups claim, don't touch membership
     if (oidcGroups === undefined) return;
 
-    if (oidcGroups.length === 0) {
-      // eslint-disable-next-line drop/no-prisma-delete
-      await prisma.user.update({
-        where: { id: userId },
-        data: { groups: { set: [] } },
-      });
-      return;
-    }
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) return;
 
-    const matchingGroups = await prisma.userGroup.findMany({
-      where: { name: { in: oidcGroups } },
-      select: { id: true },
-    });
+    const groupsToSet =
+      oidcGroups.length === 0
+        ? []
+        : (
+            await prisma.userGroup.findMany({
+              where: { name: { in: oidcGroups } },
+              select: { id: true },
+            })
+          ).map((g) => ({ id: g.id }));
 
+    // SAFETY: existence verified above via findUnique
     // eslint-disable-next-line drop/no-prisma-delete
     await prisma.user.update({
       where: { id: userId },
-      data: {
-        groups: { set: matchingGroups.map((g) => ({ id: g.id })) },
-      },
+      data: { groups: { set: groupsToSet } },
     });
   }
 

--- a/server/server/internal/userlibrary/index.ts
+++ b/server/server/internal/userlibrary/index.ts
@@ -46,10 +46,7 @@ class UserLibraryManager {
     await this.collectionRemove(gameId, userLibraryId, userId);
   }
 
-  async fetchLibrary(
-    userId: string,
-    gameFilter?: Prisma.GameWhereInput,
-  ) {
+  async fetchLibrary(userId: string, gameFilter?: Prisma.GameWhereInput) {
     const userLibraryId = await this.fetchUserLibrary(userId);
     const userLibrary = await prisma.collection.findUnique({
       where: { id: userLibraryId },
@@ -80,10 +77,7 @@ class UserLibraryManager {
     });
   }
 
-  async fetchCollections(
-    userId: string,
-    gameFilter?: Prisma.GameWhereInput,
-  ) {
+  async fetchCollections(userId: string, gameFilter?: Prisma.GameWhereInput) {
     await this.fetchUserLibrary(userId); // Ensures user library exists, doesn't have much performance impact due to caching
     return await prisma.collection.findMany({
       where: { userId, isDefault: false },

--- a/server/server/internal/userlibrary/index.ts
+++ b/server/server/internal/userlibrary/index.ts
@@ -2,6 +2,7 @@
 Handles managing collections
 */
 
+import type { Prisma } from "~/prisma/client/client";
 import cacheHandler from "../cache";
 import prisma from "../db/database";
 
@@ -45,30 +46,50 @@ class UserLibraryManager {
     await this.collectionRemove(gameId, userLibraryId, userId);
   }
 
-  async fetchLibrary(userId: string) {
+  async fetchLibrary(
+    userId: string,
+    gameFilter?: Prisma.GameWhereInput,
+  ) {
     const userLibraryId = await this.fetchUserLibrary(userId);
     const userLibrary = await prisma.collection.findUnique({
       where: { id: userLibraryId },
-      include: { entries: { include: { game: true } } },
+      include: {
+        entries: {
+          where: gameFilter ? { game: gameFilter } : undefined,
+          include: { game: true },
+        },
+      },
     });
     if (!userLibrary) throw new Error("Failed to load user library");
     return userLibrary;
   }
 
   // Will not return the default library
-  async fetchCollection(collectionId: string) {
+  async fetchCollection(
+    collectionId: string,
+    gameFilter?: Prisma.GameWhereInput,
+  ) {
     return await prisma.collection.findUnique({
       where: { id: collectionId, isDefault: false },
-      include: { entries: { include: { game: true } } },
+      include: {
+        entries: {
+          where: gameFilter ? { game: gameFilter } : undefined,
+          include: { game: true },
+        },
+      },
     });
   }
 
-  async fetchCollections(userId: string) {
+  async fetchCollections(
+    userId: string,
+    gameFilter?: Prisma.GameWhereInput,
+  ) {
     await this.fetchUserLibrary(userId); // Ensures user library exists, doesn't have much performance impact due to caching
     return await prisma.collection.findMany({
       where: { userId, isDefault: false },
       include: {
         entries: {
+          where: gameFilter ? { game: gameFilter } : undefined,
           include: {
             game: true,
           },

--- a/server/server/internal/utils/ageRestrictions.ts
+++ b/server/server/internal/utils/ageRestrictions.ts
@@ -1,0 +1,48 @@
+import type { Prisma } from "~/prisma/client/client";
+import prisma from "~/server/internal/db/database";
+
+export async function getAgeRestrictionFilter(
+  userId: string,
+  isAdmin: boolean,
+): Promise<Prisma.GameWhereInput | undefined> {
+  if (isAdmin) return undefined;
+
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: {
+      groups: {
+        select: {
+          bannedAgeRatings: {
+            select: {
+              organization: true,
+              rating: true,
+            },
+          },
+        },
+      },
+    },
+  });
+
+  if (!user) return undefined;
+
+  const bannedPairs = user.groups.flatMap((g) => g.bannedAgeRatings);
+  if (bannedPairs.length === 0) return undefined;
+
+  return {
+    AND: [
+      { ageRatings: { some: {} } },
+      {
+        NOT: {
+          ageRatings: {
+            some: {
+              OR: bannedPairs.map((bp) => ({
+                organization: bp.organization,
+                rating: bp.rating,
+              })),
+            },
+          },
+        },
+      },
+    ],
+  };
+}

--- a/server/server/internal/utils/ageRestrictions.ts
+++ b/server/server/internal/utils/ageRestrictions.ts
@@ -25,8 +25,17 @@ export async function getAgeRestrictionFilter(
 
   if (!user) return undefined;
 
-  const bannedPairs = user.groups.flatMap((g) => g.bannedAgeRatings);
-  if (bannedPairs.length === 0) return undefined;
+  const allBanned = user.groups.flatMap((g) => g.bannedAgeRatings);
+  if (allBanned.length === 0) return undefined;
+
+  // Deduplicate across groups
+  const seen = new Set<string>();
+  const bannedPairs = allBanned.filter((bp) => {
+    const key = `${bp.organization}:${bp.rating}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
 
   return {
     AND: [


### PR DESCRIPTION
Adds "Groups" as a concept to drop, with the ability to ban certain age ratings from those groups.

This completes the server side for #236 , will need to test the clients.

Flow goes in two ways:

1. If the admin is NOT using OIDC:

- Go to the Users screen
- Scroll down to groups
- Add a new group
- Add users to that group, and then ban age ratings from that group.

<img width="1533" height="665" alt="Screenshot_2026-07-29_09-30-35" src="https://github.com/user-attachments/assets/b740b7ad-c160-478f-aee5-d868880c023b" />

<img width="1535" height="878" alt="Screenshot_2026-07-29_09-30-45" src="https://github.com/user-attachments/assets/084ac2d0-8e7c-4ff0-9c52-a200a1e6ecc4" />


2. If the admin IS using OIDC:

- Go to Users screen
- See existing groups
- Ban age ratings from those groups

Both give the ability to ban age ratings from groups if desired, so an admin can create a "kids" group and from there select "ESRB AO" and "ESRB M" ratings which will no longer show up for kids.
