### PR TITLE
Fixing linux bug where client would never actually quit

### DIFF
--- a/desktop/main/app.vue
+++ b/desktop/main/app.vue
@@ -42,6 +42,10 @@ listen("update_state", (event) => {
   state.value = event.payload as AppState;
 });
 
+listen("window_visibility_change", () => {
+  document.dispatchEvent(new Event("visibilitychange"));
+});
+
 setupHooks();
 initialNavigation(state);
 

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -446,11 +446,14 @@ pub fn run() {
                 handle_server_proto_wrapper(request, responder).await;
             });
         })
-        .on_window_event(|window, event| {
-            if let WindowEvent::CloseRequested { api, .. } = event {
+        .on_window_event(|_window, event| {
+            if let WindowEvent::CloseRequested { api: _api, .. } = event {
+                // On Linux, hiding the window keeps WebkitGTK rendering in the
+                // background which causes 100% CPU usage. Let the app exit instead.
+                #[cfg(not(target_os = "linux"))]
                 run_on_tray(|| {
-                    window.hide().expect("Failed to close window in tray");
-                    api.prevent_close();
+                    _window.hide().expect("Failed to close window in tray");
+                    _api.prevent_close();
                 });
             }
         })
@@ -458,10 +461,17 @@ pub fn run() {
         .expect("error while running tauri application");
 
     app.run(|_app_handle, event| {
-        if let RunEvent::ExitRequested { code, api, .. } = event {
+        if let RunEvent::ExitRequested {
+            code: _code,
+            api: _api,
+            ..
+        } = event
+        {
+            // On Linux, let the app exit cleanly (see on_window_event above).
+            #[cfg(not(target_os = "linux"))]
             run_on_tray(|| {
-                if code.is_none() {
-                    api.prevent_exit();
+                if _code.is_none() {
+                    _api.prevent_exit();
                 }
             });
         }

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -49,7 +49,7 @@ use log4rs::{
     encode::pattern::PatternEncoder,
 };
 use tauri::{
-    AppHandle, LogicalPosition, LogicalSize, Manager, RunEvent, WebviewBuilder, WebviewUrl,
+    AppHandle, Emitter, LogicalPosition, LogicalSize, Manager, RunEvent, WebviewBuilder, WebviewUrl,
     WindowBuilder, WindowEvent,
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::TrayIconBuilder,
@@ -391,11 +391,7 @@ pub fn run() {
                                 #[cfg(target_os = "linux")]
                                 {
                                     // Resume webview rendering after showing
-                                    if let Some(win) = app.get_window("main") {
-                                        for wv in win.webviews() {
-                                            let _ = wv.eval("document.dispatchEvent(new Event('visibilitychange'))");
-                                        }
-                                    }
+                                    app_emit!(app, "window_visibility_change", ());
                                 }
 
                                 app.get_window("main")
@@ -461,9 +457,7 @@ pub fn run() {
                     // Pause webview rendering before hiding to prevent idle CPU usage
                     #[cfg(target_os = "linux")]
                     {
-                        for wv in window.webviews() {
-                            let _ = wv.eval("document.dispatchEvent(new Event('visibilitychange'))");
-                        }
+                        let _ = window.app_handle().emit("window_visibility_change", ());
                     }
 
                     window.hide().expect("Failed to hide window in tray");

--- a/desktop/src-tauri/src/lib.rs
+++ b/desktop/src-tauri/src/lib.rs
@@ -388,9 +388,18 @@ pub fn run() {
                         .menu(&menu)
                         .on_menu_event(|app, event| match event.id.as_ref() {
                             "open" => {
-                                app.webview_windows()
-                                    .get("frontend")
-                                    .expect("Failed to get webview")
+                                #[cfg(target_os = "linux")]
+                                {
+                                    // Resume webview rendering after showing
+                                    if let Some(win) = app.get_window("main") {
+                                        for wv in win.webviews() {
+                                            let _ = wv.eval("document.dispatchEvent(new Event('visibilitychange'))");
+                                        }
+                                    }
+                                }
+
+                                app.get_window("main")
+                                    .expect("Failed to get main window")
                                     .show()
                                     .expect("Failed to show window");
                             }
@@ -446,14 +455,19 @@ pub fn run() {
                 handle_server_proto_wrapper(request, responder).await;
             });
         })
-        .on_window_event(|_window, event| {
-            if let WindowEvent::CloseRequested { api: _api, .. } = event {
-                // On Linux, hiding the window keeps WebkitGTK rendering in the
-                // background which causes 100% CPU usage. Let the app exit instead.
-                #[cfg(not(target_os = "linux"))]
+        .on_window_event(|window, event| {
+            if let WindowEvent::CloseRequested { api, .. } = event {
                 run_on_tray(|| {
-                    _window.hide().expect("Failed to close window in tray");
-                    _api.prevent_close();
+                    // Pause webview rendering before hiding to prevent idle CPU usage
+                    #[cfg(target_os = "linux")]
+                    {
+                        for wv in window.webviews() {
+                            let _ = wv.eval("document.dispatchEvent(new Event('visibilitychange'))");
+                        }
+                    }
+
+                    window.hide().expect("Failed to hide window in tray");
+                    api.prevent_close();
                 });
             }
         })
@@ -462,16 +476,14 @@ pub fn run() {
 
     app.run(|_app_handle, event| {
         if let RunEvent::ExitRequested {
-            code: _code,
-            api: _api,
+            code,
+            api,
             ..
         } = event
         {
-            // On Linux, let the app exit cleanly (see on_window_event above).
-            #[cfg(not(target_os = "linux"))]
             run_on_tray(|| {
-                if _code.is_none() {
-                    _api.prevent_exit();
+                if code.is_none() {
+                    api.prevent_exit();
                 }
             });
         }


### PR DESCRIPTION
When you exit the Drop app on Linux the game "minimizes" to the tray, except in Linux's case it will keep running indefinitely in the background. Until it's forcefully killed it will keep running and prevent restarting the app.

Traced this to the hide behavior, WebkitGTK will keep rendering the webview even after the window is hidden. This invisible render loop pegs a CPU core at 100% indefinitely until the process is killed.

In Linux now hitting the X button will fully close the app.