### PR TITLE
Fix steam metadata import if full_description is missing

### DIFF
--- a/server/server/internal/metadata/steam.ts
+++ b/server/server/internal/metadata/steam.ts
@@ -129,7 +129,8 @@ interface SteamAppDetailsLarge extends SteamAppDetailsSmall {
       ordinal: number;
     }[];
   };
-  full_description: string;
+  // Can be undefined if the game is not available in the country of the request
+  full_description: string | undefined;
 }
 
 interface SteamAppDetailsPackage {
@@ -418,7 +419,7 @@ export class SteamProvider implements MetadataProvider {
       );
     } else {
       context?.logger.info("Using fallback description from basic game info");
-      description = currentGame.full_description;
+      description = currentGame.full_description ?? "";
     }
 
     context?.progress(90);
@@ -485,7 +486,7 @@ export class SteamProvider implements MetadataProvider {
       bannerId: banner,
       coverId: cover,
       images,
-    } as GameMetadata;
+    } satisfies GameMetadata;
   }
 
   async fetchCompany({


### PR DESCRIPTION
When trying to import a game which is restricted in your country, steam seems to not provide a full_description. This caused errors while importing, because the undefined was unexpected here. I made this case explicit and the code a bit more typesafe to fix this error and at least allows to import the metadata you have access to via steam.

Fixes #403.