### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/client-release.yml
+++ b/.github/workflows/client-release.yml
@@ -36,7 +36,7 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -51,7 +51,6 @@ jobs:
           node-version: lts/*
           cache: pnpm
 
-
       - name: install Rust nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -61,7 +60,7 @@ jobs:
       - name: Rust cache
         uses: swatinem/rust-cache@v2
         with:
-          workspaces: './desktop/src-tauri -> target'
+          workspaces: "./desktop/src-tauri -> target"
 
       - name: install dependencies (ubuntu only)
         if: matrix.platform == 'ubuntu-22.04' || matrix.platform == 'ubuntu-22.04-arm' # This must match the platform value defined above.
@@ -137,4 +136,4 @@ jobs:
           releaseDraft: false
           prerelease: true
           args: ${{ matrix.args }}
-          projectPath: './desktop'
+          projectPath: "./desktop"

--- a/.github/workflows/client-release.yml
+++ b/.github/workflows/client-release.yml
@@ -46,7 +46,7 @@ jobs:
           run_install: false
 
       - name: setup node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: lts/*
           cache: pnpm

--- a/.github/workflows/client-release.yml
+++ b/.github/workflows/client-release.yml
@@ -41,7 +41,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 

--- a/.github/workflows/droplet-ci.yml
+++ b/.github/workflows/droplet-ci.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: libraries/droplet
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
         with:
           run_install: false
 

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -55,7 +55,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Restore cache
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             sites/promo/.next/cache

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Setup Pages
         id: setup_pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
 
       - name: Restore cache
         uses: actions/cache@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -39,7 +39,7 @@ jobs:
           run_install: false
 
       - name: Install Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "22"
           cache: "pnpm"

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -35,7 +35,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: lts/*
           cache: "pnpm"
@@ -58,7 +58,7 @@ jobs:
         uses: pnpm/action-setup@v6
 
       - name: Setup Node.js environment
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: lts/*
           cache: "pnpm"

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@v6
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v4

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -46,7 +46,7 @@ jobs:
           images: ${{ env.REGISTRY_IMAGE }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -120,7 +120,7 @@ jobs:
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Build and push by digest
         id: build
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -56,7 +56,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Determine final version
         id: get_final_ver
@@ -127,7 +127,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v6

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -53,7 +53,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -113,7 +113,7 @@ jobs:
       contents: read
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: ${{ runner.temp }}/digests
           pattern: digests-*

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
 
@@ -130,7 +130,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
       - name: Extract metadata (tags, labels) for Docker
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: |
             ghcr.io/drop-OSS/drop

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -27,7 +27,7 @@ jobs:
       contents: read
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 3 # fix for when this gets triggered by tag
           fetch-tags: true

--- a/.github/workflows/server-release.yml
+++ b/.github/workflows/server-release.yml
@@ -97,7 +97,7 @@ jobs:
           touch "${{ runner.temp }}/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: digests-${{ env.PLATFORM_PAIR }}
           path: ${{ runner.temp }}/digests/*

--- a/.github/workflows/torrential-ci.yml
+++ b/.github/workflows/torrential-ci.yml
@@ -34,7 +34,7 @@ jobs:
         working-directory: torrential
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@nightly

--- a/libraries/native_model/.github/workflows/build_and_test_release.yml
+++ b/libraries/native_model/.github/workflows/build_and_test_release.yml
@@ -2,9 +2,9 @@ name: Build Test Release
 
 on:
   push:
-    branches: [ main, next ]
+    branches: [main, next]
   pull_request:
-    branches: [ main, next ]
+    branches: [main, next]
   workflow_dispatch:
 
 jobs:
@@ -16,7 +16,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         toolchain: [stable]
     steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
+      - uses: actions/checkout@v7
       - name: Setup Rust
         uses: actions-rs/toolchain@v1
         with:
@@ -25,7 +25,7 @@ jobs:
       - uses: extractions/setup-just@v3
       - uses: hustcer/setup-nu@v3.23
         with:
-          version: '0.105.1'
+          version: "0.105.1"
       - name: Just version
         run: just --version
       - name: Build
@@ -42,7 +42,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
+        uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 0
@@ -50,7 +50,7 @@ jobs:
       - name: install npm
         uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version: "20"
 
       - name: Semantic Release
         uses: cycjimmy/semantic-release-action@v4

--- a/libraries/native_model/.github/workflows/build_and_test_release.yml
+++ b/libraries/native_model/.github/workflows/build_and_test_release.yml
@@ -48,7 +48,7 @@ jobs:
           fetch-depth: 0
 
       - name: install npm
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 

--- a/libraries/native_model/.github/workflows/clippy_check.yml
+++ b/libraries/native_model/.github/workflows/clippy_check.yml
@@ -2,11 +2,11 @@ name: Clippy Check
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main, next ]
+    branches: [main, next]
   schedule:
-    - cron:  '0 23 * * 4'
+    - cron: "0 23 * * 4"
 
 env:
   RUST_BACKTRACE: full
@@ -15,16 +15,16 @@ jobs:
   clippy_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
       - uses: extractions/setup-just@v3
       - uses: hustcer/setup-nu@v3.23
         with:
-          version: '0.105.1'
+          version: "0.105.1"
         env:
-            GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
+          GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
       - name: Just version
         run: just --version
       - name: Clippy Check
-        run: just clippy_check 
+        run: just clippy_check

--- a/libraries/native_model/.github/workflows/conventional_commits.yml
+++ b/libraries/native_model/.github/workflows/conventional_commits.yml
@@ -2,12 +2,12 @@ name: Conventional Commits
 
 on:
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   build:
     name: Conventional Commits
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6
+      - uses: actions/checkout@v7
       - uses: webiny/action-conventional-commits@v1.3.1

--- a/libraries/native_model/.github/workflows/fmt_check.yml
+++ b/libraries/native_model/.github/workflows/fmt_check.yml
@@ -2,11 +2,11 @@ name: Fmt Check
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main, next ]
+    branches: [main, next]
   schedule:
-    - cron:  '0 23 * * 4'
+    - cron: "0 23 * * 4"
 
 env:
   RUST_BACKTRACE: full
@@ -15,16 +15,16 @@ jobs:
   fmt_check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
       - uses: extractions/setup-just@v3
       - uses: hustcer/setup-nu@v3.23
         with:
-          version: '0.105.1'
+          version: "0.105.1"
         env:
-            GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
+          GITHUB_TOKEN: ${{ secrets.PAT_GLOBAL }}
       - name: Just version
         run: just --version
       - name: Fmt Check
-        run: just fmt_check 
+        run: just fmt_check

--- a/sites/docs/.github/workflows/deploy.yml
+++ b/sites/docs/.github/workflows/deploy.yml
@@ -19,14 +19,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
       - name: Install, build, and upload your site output
         uses: withastro/action@v5
         # with:
-            # path: . # The root location of your Astro project inside the repository. (optional)
-            # node-version: 22 # The specific version of Node that should be used to build your site. Defaults to 22. (optional)
-            # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
-            # build-cmd: pnpm run build # The command to run to build your site. Runs the package build script/task by default. (optional)
+        # path: . # The root location of your Astro project inside the repository. (optional)
+        # node-version: 22 # The specific version of Node that should be used to build your site. Defaults to 22. (optional)
+        # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
+        # build-cmd: pnpm run build # The command to run to build your site. Runs the package build script/task by default. (optional)
 
   deploy:
     needs: build


### PR DESCRIPTION
I noticed [some warnings in the CI](https://github.com/Drop-OSS/drop/actions/runs/33312759201), that some things still use Node 20 which is deprecated. I therefore updated most actions in the repo. I checked the changelogs and THINK that everything on a critical path like the release should still work, but I guess we can only be sure on the next run :sweat_smile: Therefore I'm of course open to removing some updates on those paths.

I also skipped `tauri-apps/tauri-action` because I think this could break, if I read the changelog for v1.

I'm not sure, if the decision to not handle updating github actions is a deliberate one, therefore I didn't do it in this PR, but Dependabot could do these updates for you (or at least open PRs for it), if you want via the [`github-actions` ecosystem](https://docs.github.com/en/code-security/reference/supply-chain-security/supported-ecosystems-and-repositories#supported-ecosystems-maintained-by-github). For that a `.github/dependabot.yml` would be needed.
