### PR TITLE
Fix delta updates deleting nested files on Windows

### DIFF
--- a/desktop/src-tauri/games/src/downloads/download_agent.rs
+++ b/desktop/src-tauri/games/src/downloads/download_agent.rs
@@ -308,7 +308,7 @@ impl GameDownloadAgent {
         let current_file_tree = self.scan_filetree(base_path)?;
 
         for file in current_file_tree {
-            let filename = file.strip_prefix(base_path)?.to_string_lossy().to_string();
+            let filename = file.strip_prefix(base_path)?.to_string_lossy().replace('\\', "/");
             let needed = file_list.contains_key(&filename) || filename == ".dropdata";
             if !needed {
                 debug!("deleted {}", file.display());


### PR DESCRIPTION
## Summary
On Windows, `GameDownloadAgent::run()`'s pre-download prune step compares locally-scanned
relative paths against the manifest's `file_list` keys using an exact string match.
`file_list` entries always use `/` regardless of which OS produced the manifest, but a
Windows path scan yields `\`-separated strings, so every file inside a subdirectory fails
the match and gets deleted. Root-level files (no separator to disagree on) survive by
coincidence, which is why the failure mode looks like "Unity `_Data` folders lose
everything, exe/dll at the root are fine."

Fix: normalize the scanned path to `/` before the lookup.

Confirmed against a live server: of one game's `file_list`, 401/407 entries contained `/`,
and the remaining 6 were exactly the root-level files that survive today — matching the
reported symptom exactly.

## Disclosure
Per the server project's contribution guidelines (no-AI-contributions policy): this fix
was investigated and written with AI assistance (Claude Code). I'm disclosing that up
front rather than passing it off as independent work, and leaving it to maintainer
discretion whether to accept it as-is.

## Test plan
- [ ] `cargo build -p games`
- [ ] Reproduce: install a Unity game, trigger an update/reinstall, confirm `_Data/Managed`
      etc. survive intact