### PR TITLE
Fix Install in the missing-dependency modal

### DIFF
--- a/desktop/main/components/DependencyRequiredModal.vue
+++ b/desktop/main/components/DependencyRequiredModal.vue
@@ -95,6 +95,7 @@ async function install() {
       versionId: model.value.versionId,
       installDir: installDir.value,
       targetPlatform: version.platform,
+      enableUpdates: versionOptions.indexOf(version) === 0,
     });
     cancel();
   } catch (error) {


### PR DESCRIPTION
## Summary
When a game needs an emulator that isn't installed, pressing Play shows the "Missing required dependency" modal. Its Install button calls `download_game` without `enableUpdates`, which the command requires, so the click fails with:

```
invalid args `enableUpdates` for command `download_game`: command download_game missing required key enableUpdates
```

The library page's install flow already passes `enableUpdates: isLatest`. This does the same in the modal: true when the version being installed is the latest one.

Reproduced with an Emulator entry linked from a game's launch command: the modal opens fine, and Install fails with the error above until this change.

## Test plan
- [ ] Import an Emulator with a launch command, and a game whose launch command uses it.
- [ ] With the emulator not installed, press Play on the game -> the modal appears -> Install starts the emulator download instead of erroring.
- [ ] After it downloads, press Play again -> the game launches through the emulator.
