### PR TITLE
Cache fetched games under the key the download agent reads

### DIFF
--- a/desktop/src-tauri/src/games.rs
+++ b/desktop/src-tauri/src/games.rs
@@ -248,7 +248,7 @@ pub async fn fetch_game_logic(
 
     let data = FetchGameStruct::new(game.clone(), status, version);
 
-    cache_object(&id, &game)?;
+    cache_object(&format!("game/{}", id), &game)?;
 
     Ok(data)
 }
@@ -341,7 +341,7 @@ pub async fn fetch_game_logic_offline(
     };
 
     let status = GameStatusManager::fetch_state(&id, &db_handle);
-    let game = get_cached_object::<Game>(&id)?;
+    let game = get_cached_object::<Game>(&format!("game/{}", id))?;
 
     drop(db_handle);
 


### PR DESCRIPTION
## Summary
`fetch_game_logic` saves a fetched game under the cache key `<id>` (`games.rs:251`), but the download agent looks it up under `game/<id>` (`download_agent.rs:83`). Only the library list writes `game/<id>`. So a game that isn't in the user's library - for example an emulator pulled in as a dependency - is never found, and the download agent falls back to the game's id for the folder name: it installs into `<install dir>/<uuid>` instead of `<install dir>/<name>`.

Reproduced: with nothing cached, a required emulator installed into `<install dir>\<uuid>`; with the cache entry present, into `<install dir>\<name>`. The offline path (`fetch_game_logic_offline`) read the old key, so it now reads the new one.

## Test plan
- [ ] Install a game that requires an emulator you don't have in your library; the emulator lands in `<install dir>/<its name>`, not a UUID folder.
- [ ] Open a game page, go offline, reopen it: it still loads.
