### PR TITLE
Keep the download queue moving after a failed download

### DIFF
--- a/desktop/src-tauri/download_manager/src/download_manager_builder.rs
+++ b/desktop/src-tauri/download_manager/src/download_manager_builder.rs
@@ -357,6 +357,7 @@ impl DownloadManagerBuilder {
         }
         self.push_ui_queue_update();
         self.set_status(DownloadManagerStatus::Error);
+        send!(self.sender, DownloadManagerSignal::Go);
     }
     async fn manage_cancel_signal(&mut self, meta: &DownloadableMetadata) {
         // If the current download is the one we're tryna cancel


### PR DESCRIPTION
Found this while hunting another bug.  Haven't reproduced it myself, just noticed the inconsistency and thought I'd file.  Take it or leave it.

## Summary
When a download fails, `manage_error_signal` removes it from the queue and sets the Error status, but doesn't send `Go` - so the next queued download (for example an emulator queued right after its game) never starts on its own. `manage_completed_signal` and `manage_cancel_signal` both send `Go`; this does the same. The Error status is still set, so the UI still shows the failure.

## Test plan
- [ ] Queue two downloads and make the first one fail (for example, block its manifest request); the second one starts on its own.
- [ ] `cargo build` for `desktop/src-tauri`.
